### PR TITLE
feat: add endpoint POST /api/v1/workouts/{id}/exercises para adicionar exercise ao workout

### DIFF
--- a/src/main/java/br/com/emendes/workout_tracker_api/WorkoutTrackerApiApplication.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/WorkoutTrackerApiApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class WorkoutTrackerApplication {
+public class WorkoutTrackerApiApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(WorkoutTrackerApplication.class, args);
+		SpringApplication.run(WorkoutTrackerApiApplication.class, args);
 	}
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
@@ -1,30 +1,29 @@
 package br.com.emendes.workout_tracker_api.controller;
 
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.service.WorkoutService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 
 /**
- * Classe controller responsável pelo endpoint /api/v1/workout/**.
+ * Classe controller responsável pelo endpoint /api/v1/workouts/**.
  */
 @RestController
-@RequestMapping("/api/v1/workout")
+@RequestMapping("/api/v1/workouts")
 @RequiredArgsConstructor
 public class WorkoutController {
 
   private final WorkoutService workoutService;
 
   /**
-   * Método responsável pelo endpoint POST /api/v1/workout para criação de recurso Workout.
+   * Método responsável pelo endpoint POST /api/v1/workouts para criação de recurso Workout.
    *
    * @param workoutCreateRequest DTO com os dados de criação de Workout.
    * @param uriBuilder           objeto que mantém o host do endpoint para construção do header location.
@@ -36,6 +35,26 @@ public class WorkoutController {
     URI location = uriBuilder.path("/api/v1/workout/{id}").build(workoutResponse.id());
 
     return ResponseEntity.created(location).body(workoutResponse);
+  }
+
+  /**
+   * Método responsável pelo endpoint POST /api/v1/workouts/{workoutId}/exercises
+   * para adicionar o recurso Exercise ao Workout.
+   *
+   * @param workoutId             identificador do Workout que receberá o Exercise.
+   * @param exerciseCreateRequest objeto contendo as informações do Exercise que será adicionado.
+   * @param uriBuilder            objeto que mantém o host do endpoint para construção do header location.
+   */
+  @PostMapping("/{workoutId}/exercises")
+  ResponseEntity<ExerciseResponse> addExercise(
+      @PathVariable("workoutId") Long workoutId,
+      @RequestBody ExerciseCreateRequest exerciseCreateRequest,
+      UriComponentsBuilder uriBuilder) {
+    ExerciseResponse exerciseResponse = workoutService.addExercise(workoutId, exerciseCreateRequest);
+    URI location = uriBuilder.path("/api/v1/workouts/{workoutId}/exercises/{exerciseId}")
+        .build(workoutId, exerciseResponse.id());
+
+    return ResponseEntity.created(location).body(exerciseResponse);
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/request/ExerciseCreateRequest.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/request/ExerciseCreateRequest.java
@@ -1,0 +1,34 @@
+package br.com.emendes.workout_tracker_api.dto.request;
+
+import br.com.emendes.workout_tracker_api.validation.annotation.NullOrNotBlank;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+/**
+ * Record DTO com os dados para criação de Exercise.
+ *
+ * @param name        nome do Exercise.
+ * @param description descrição do Exercise (não obrigatório).
+ * @param additional  informação adicional do Exercise (não obrigatório).
+ * @param sets        número de sets do Exercise.
+ * @param weight      carga usado no Exercise.
+ */
+@Builder
+public record ExerciseCreateRequest(
+    @NotBlank(message = "name must not be blank or null")
+    @Size(min = 1, max = 100, message = "name must contain between {min} and {max} characters long")
+    String name,
+    @NullOrNotBlank(message = "description must be null or not be blank")
+    @Size(max = 255, message = "description must contain max {max} characters long")
+    String description,
+    @NullOrNotBlank(message = "additional must be null or not be blank")
+    @Size(min = 1, max = 150, message = "additional must contain between {min} and {max} characters long")
+    String additional,
+    @Positive(message = "sets must be positive")
+    int sets,
+    @Positive(message = "weight must be positive")
+    double weight
+) {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/response/ExerciseResponse.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/response/ExerciseResponse.java
@@ -1,0 +1,30 @@
+package br.com.emendes.workout_tracker_api.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * Record DTO com os dados de Exercise.
+ *
+ * @param id          identificador do Exercise.
+ * @param name        nome do Exercise.
+ * @param description descrição do Exercise.
+ * @param additional  informações adicionais do Exercise.
+ * @param sets        número de séries do Exercise.
+ * @param weight      peso do Exercise.
+ * @param createdAt   data de criação do Exercise.
+ * @param updatedAt   data de atualização do Exercise.
+ */
+@Builder
+public record ExerciseResponse(
+    Long id,
+    String name,
+    String description,
+    String additional,
+    int sets,
+    double weight,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/exception/WorkoutNotFoundException.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/exception/WorkoutNotFoundException.java
@@ -1,0 +1,12 @@
+package br.com.emendes.workout_tracker_api.exception;
+
+/**
+ * Exception para ser lançada em caso de Workout não encontrado.
+ */
+public class WorkoutNotFoundException extends RuntimeException {
+
+  public WorkoutNotFoundException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/handler/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.emendes.workout_tracker_api.handler;
 
+import br.com.emendes.workout_tracker_api.exception.WorkoutNotFoundException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     problemDetail.setProperty("messages", messages);
 
     return ResponseEntity.badRequest().body(problemDetail);
+  }
+
+  @ExceptionHandler(WorkoutNotFoundException.class)
+  public ResponseEntity<ProblemDetail> handleWorkoutNotFound(WorkoutNotFoundException exception) {
+    ProblemDetail problemDetail = ProblemDetail.forStatus(404);
+    problemDetail.setTitle("Not found");
+    problemDetail.setDetail(exception.getMessage());
+    problemDetail.setType(URI.create("https://github.com/Edson-Mendes/workout-tracker-api"));
+
+    return ResponseEntity.status(404).body(problemDetail);
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/ExerciseMapper.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/ExerciseMapper.java
@@ -1,0 +1,32 @@
+package br.com.emendes.workout_tracker_api.mapper;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+
+/**
+ * Interface com as abstrações para mapeamento de do recurso Exercise.
+ */
+public interface ExerciseMapper {
+
+  /**
+   * Mapeia um objeto {@link ExerciseCreateRequest} para {@link Exercise}.
+   * <br><br>
+   * O campo {@code Exercise.createdAt} tem o valor padrão o horário de criação de Exercise,
+   * e o valor padrão de {@code Exercise.updatedAt} é null.
+   *
+   * @param exerciseCreateRequest objeto com os dados de criação Exercise.
+   * @param workoutId             identificador do Workout relacionado ao Exercise.
+   * @return Exercise com os dados de ExerciseCreateRequest.
+   */
+  Exercise toExercise(Long workoutId, ExerciseCreateRequest exerciseCreateRequest);
+
+  /**
+   * Mapeia um objeto {@link Exercise} para {@link ExerciseResponse}.
+   *
+   * @param exercise objeto que será mapeado.
+   * @return ExerciseResponse com as informações de Exercise.
+   */
+  ExerciseResponse toExerciseResponse(Exercise exercise);
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/ExerciseMapperImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/ExerciseMapperImpl.java
@@ -1,0 +1,51 @@
+package br.com.emendes.workout_tracker_api.mapper.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.mapper.ExerciseMapper;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Workout;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import java.time.LocalDateTime;
+
+/**
+ * Implementação de {@link ExerciseMapper}.
+ */
+@Component
+public class ExerciseMapperImpl implements ExerciseMapper {
+
+  @Override
+  public Exercise toExercise(Long workoutId, ExerciseCreateRequest exerciseCreateRequest) {
+    Assert.notNull(exerciseCreateRequest, "exerciseCreateRequest must not be null");
+    Assert.notNull(workoutId, "workoutId must not be null");
+
+    return Exercise.builder()
+        .name(exerciseCreateRequest.name())
+        .description(exerciseCreateRequest.description())
+        .additional(exerciseCreateRequest.additional())
+        .sets(exerciseCreateRequest.sets())
+        .weight(exerciseCreateRequest.weight())
+        .createdAt(LocalDateTime.now())
+        .workout(Workout.builder().id(workoutId).build())
+        .build();
+  }
+
+  @Override
+  public ExerciseResponse toExerciseResponse(Exercise exercise) {
+    Assert.notNull(exercise, "exercise must not be null");
+
+    return ExerciseResponse.builder()
+        .id(exercise.getId())
+        .name(exercise.getName())
+        .description(exercise.getDescription())
+        .additional(exercise.getAdditional())
+        .sets(exercise.getSets())
+        .weight(exercise.getWeight())
+        .createdAt(exercise.getCreatedAt())
+        .updatedAt(exercise.getUpdatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Exercise.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Exercise.java
@@ -1,0 +1,43 @@
+package br.com.emendes.workout_tracker_api.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * Classe que representa a entidade Exercise do banco de dados.
+ */
+@Entity
+@Table(name = "tb_exercise")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Exercise {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  @EqualsAndHashCode.Include
+  private Long id;
+  @Column(name = "name", nullable = false, length = 100)
+  private String name;
+  @Column(name = "description")
+  private String description;
+  @Column(name = "additional", length = 150)
+  private String additional;
+  @Column(name = "sets", nullable = false)
+  private int sets;
+  @Column(name = "weight", nullable = false)
+  private double weight;
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  private Workout workout;
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/repository/ExerciseRepository.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/repository/ExerciseRepository.java
@@ -1,0 +1,10 @@
+package br.com.emendes.workout_tracker_api.repository;
+
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Interface repository com as abstrações para interação com o recurso Exercise no banco de dados.
+ */
+public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/ExerciseService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/ExerciseService.java
@@ -1,0 +1,20 @@
+package br.com.emendes.workout_tracker_api.service;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+
+/**
+ * Interface com as abstrações para manipulação do recurso Exercise.
+ */
+public interface ExerciseService {
+
+  /**
+   * Cria um Exercise.
+   *
+   * @param exerciseCreateRequest objeto contendo os dados para criação de um Exercise.
+   * @param workoutId             identificador do workout relacionado com Exercise.
+   * @return ExerciseResponse contendo as informações do Exercise criado.
+   */
+  ExerciseResponse create(Long workoutId, ExerciseCreateRequest exerciseCreateRequest);
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
@@ -1,8 +1,11 @@
 package br.com.emendes.workout_tracker_api.service;
 
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -18,5 +21,16 @@ public interface WorkoutService {
    * @return WorkoutResponse contendo informações do Workout criado.
    */
   WorkoutResponse create(@Valid WorkoutCreateRequest workoutCreateRequest);
+
+  /**
+   * Adiciona um Exercise a um Workout.
+   *
+   * @param workoutId             identificador do Workout que terá Exercise adicionado.
+   * @param exerciseCreateRequest objeto contendo os dados de criação de Exercise.
+   * @return ExerciseResponse contendo as informações do Exercise adicionado.
+   */
+  ExerciseResponse addExercise(
+      @NotNull(message = "workoutId must not be null") Long workoutId,
+      @Valid ExerciseCreateRequest exerciseCreateRequest);
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/ExerciseServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/ExerciseServiceImpl.java
@@ -1,0 +1,34 @@
+package br.com.emendes.workout_tracker_api.service.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.mapper.ExerciseMapper;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.repository.ExerciseRepository;
+import br.com.emendes.workout_tracker_api.service.ExerciseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação de {@link ExerciseService}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExerciseServiceImpl implements ExerciseService {
+
+  private final ExerciseMapper exerciseMapper;
+  private final ExerciseRepository exerciseRepository;
+
+  @Override
+  public ExerciseResponse create(Long workoutId, ExerciseCreateRequest exerciseCreateRequest) {
+    log.info("attempt to create Exercise");
+    Exercise exercise = exerciseMapper.toExercise(workoutId, exerciseCreateRequest);
+    exercise = exerciseRepository.save(exercise);
+    log.info("exercise created successfully with id: {}", exercise.getId());
+
+    return exerciseMapper.toExerciseResponse(exercise);
+  }
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
@@ -1,10 +1,14 @@
 package br.com.emendes.workout_tracker_api.service.impl;
 
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
+import br.com.emendes.workout_tracker_api.exception.WorkoutNotFoundException;
 import br.com.emendes.workout_tracker_api.mapper.WorkoutMapper;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
 import br.com.emendes.workout_tracker_api.repository.WorkoutRepository;
+import br.com.emendes.workout_tracker_api.service.ExerciseService;
 import br.com.emendes.workout_tracker_api.service.WorkoutService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +24,7 @@ public class WorkoutServiceImpl implements WorkoutService {
 
   private final WorkoutRepository workoutRepository;
   private final WorkoutMapper workoutMapper;
+  private final ExerciseService exerciseService;
 
   @Override
   public WorkoutResponse create(WorkoutCreateRequest workoutCreateRequest) {
@@ -29,6 +34,19 @@ public class WorkoutServiceImpl implements WorkoutService {
     log.info("workout created successfully with id: {}", workout.getId());
 
     return workoutMapper.toWorkoutResponse(workout);
+  }
+
+  @Override
+  public ExerciseResponse addExercise(Long workoutId, ExerciseCreateRequest exerciseCreateRequest) {
+    log.info("attempt to add Exercise to workout with id: {}", workoutId);
+    if (workoutRepository.existsById(workoutId)) {
+      ExerciseResponse exerciseResponse = exerciseService.create(workoutId, exerciseCreateRequest);
+
+      log.info("exercise added successfully with id: {}", exerciseResponse.id());
+      return exerciseResponse;
+    }
+
+    throw new WorkoutNotFoundException("workout not found with id: %s".formatted(workoutId));
   }
 
 }

--- a/src/main/resources/db/migration/V01__CREATE_TABLE_WORKOUT.sql
+++ b/src/main/resources/db/migration/V01__CREATE_TABLE_WORKOUT.sql
@@ -4,5 +4,5 @@ CREATE TABLE tb_workout (
     description VARCHAR(255) NULL,
     is_in_use boolean NOT NULL,
     created_at timestamp NOT NULL,
-    CONSTRAINT tb_workout_f_id_pk PRIMARY KEY (id)
+    CONSTRAINT tb_workout__f_id__pk PRIMARY KEY (id)
 );

--- a/src/main/resources/db/migration/V02__CREATE_TABLE_EXERCISE.sql
+++ b/src/main/resources/db/migration/V02__CREATE_TABLE_EXERCISE.sql
@@ -1,0 +1,13 @@
+CREATE TABLE tb_exercise (
+    id bigserial NOT NULL,
+    name varchar(100) NOT NULL,
+    description varchar(255) NULL,
+    additional varchar(150) NULL,
+    sets int NOT NULL,
+    weight real NOT NULL,
+    created_at timestamp NOT NULL,
+    updated_at timestamp NULL,
+    workout_id bigint NOT NULL,
+    CONSTRAINT tb_exercise__f_id__pk PRIMARY KEY (id),
+    CONSTRAINT tb_exercise__f_workout_id__fk FOREIGN KEY (workout_id) REFERENCES tb_workout(id)
+);

--- a/src/test/java/br/com/emendes/workout_tracker_api/integration/controller/WorkoutControllerIT.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/integration/controller/WorkoutControllerIT.java
@@ -1,9 +1,11 @@
 package br.com.emendes.workout_tracker_api.integration.controller;
 
 import br.com.emendes.workout_tracker_api.controller.WorkoutController;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.mapper.WorkoutMapper;
 import br.com.emendes.workout_tracker_api.repository.WorkoutRepository;
+import br.com.emendes.workout_tracker_api.service.ExerciseService;
 import br.com.emendes.workout_tracker_api.service.WorkoutService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
 
+import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.exerciseResponse;
 import static br.com.emendes.workout_tracker_api.util.faker.WorkoutFaker.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,11 +49,16 @@ class WorkoutControllerIT {
   private WorkoutMapper workoutMapperMock;
   @MockitoBean
   private WorkoutRepository workoutRepositoryMock;
+  @MockitoBean
+  private ExerciseService exerciseServiceMock;
+
+  public static final String CONTENT_TYPE = "application/json;charset=UTF-8";
 
   @Nested
+  @DisplayName("Create Endpoint")
   class CreateEndpoint {
 
-    private static final String CREATE_URI = "/api/v1/workout";
+    private static final String CREATE_URI = "/api/v1/workouts";
 
     @Test
     @DisplayName("POST /api/v1/workout must return status 201 when create workout successfully")
@@ -66,7 +74,7 @@ class WorkoutControllerIT {
           }
           """;
 
-      mockMvc.perform(post(CREATE_URI).contentType("application/json;charset=UTF-8").content(requestBody))
+      mockMvc.perform(post(CREATE_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andExpect(status().isCreated());
     }
 
@@ -84,7 +92,7 @@ class WorkoutControllerIT {
           }
           """;
 
-      String actualResponseBody = mockMvc.perform(post(CREATE_URI).contentType("application/json;charset=UTF-8").content(requestBody))
+      String actualResponseBody = mockMvc.perform(post(CREATE_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
       WorkoutResponse actualWorkoutResponse = mapper.readValue(actualResponseBody, WorkoutResponse.class);
 
@@ -106,7 +114,7 @@ class WorkoutControllerIT {
           }
           """;
 
-      mockMvc.perform(post(CREATE_URI).contentType("application/json;charset=UTF-8").content(requestBody))
+      mockMvc.perform(post(CREATE_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andExpect(status().isBadRequest());
     }
 
@@ -120,21 +128,168 @@ class WorkoutControllerIT {
           }
           """;
 
-      String actualResponseBody = mockMvc.perform(post(CREATE_URI).contentType("application/json;charset=UTF-8").content(requestBody))
+      String actualResponseBody = mockMvc.perform(post(CREATE_URI).contentType(CONTENT_TYPE).content(requestBody))
           .andReturn().getResponse().getContentAsString();
       ProblemDetail actualProblemDetail = mapper.readValue(actualResponseBody, ProblemDetail.class);
 
       assertThat(actualProblemDetail).isNotNull()
           .hasFieldOrPropertyWithValue("title", "Bad request")
           .hasFieldOrPropertyWithValue("detail", "Some fields are invalid")
-          .hasFieldOrPropertyWithValue("status", 400)
-          .hasFieldOrProperty("properties");
+          .hasFieldOrPropertyWithValue("status", 400);
+      assertThat(actualProblemDetail.getProperties()).isNotNull();
+      String[] actualFields = ((String) actualProblemDetail.getProperties().get("fields")).split(";");
+      String[] actualMessages = ((String) actualProblemDetail.getProperties().get("messages")).split(";");
+
+      assertThat(actualFields).isNotNull().hasSize(1).contains("description");
+      assertThat(actualMessages).isNotNull().hasSize(1).contains("description must be null or not be blank");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Add Exercise Endpoint")
+  class AddExerciseEndpoint {
+
+    private static final String ADD_EXERCISE_URI = "/api/v1/workouts/{workoutId}/exercises";
+
+    @Test
+    @DisplayName("addExercise must return status 201 when add exercise successfully")
+    void addExercise_MustReturnStatus201_WhenAddExerciseSuccessfully() throws Exception {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(true);
+      when(exerciseServiceMock.create(any(), any())).thenReturn(exerciseResponse());
+
+      String requestBody = """
+          {
+            "name": "Leg press",
+            "description": "Exercise that focuses on the quadriceps",
+            "additional": "Apply the Rest in Pause technique in the last set",
+            "sets": 4,
+            "weight": 50.0
+          }
+          """;
+
+      mockMvc.perform(post(ADD_EXERCISE_URI, 1_000L).contentType(CONTENT_TYPE).content(requestBody))
+          .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("addExercise must return ExerciseResponse when add exercise successfully")
+    void addExercise_MustReturnExerciseResponse_WhenAddExerciseSuccessfully() throws Exception {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(true);
+      when(exerciseServiceMock.create(any(), any())).thenReturn(exerciseResponse());
+
+      String requestBody = """
+          {
+            "name": "Leg press",
+            "description": "Exercise that focuses on the quadriceps",
+            "additional": "Apply the Rest in Pause technique in the last set",
+            "sets": 4,
+            "weight": 50.0
+          }
+          """;
+
+      String actualResponseBody = mockMvc.perform(post(ADD_EXERCISE_URI, 1_000L).contentType(CONTENT_TYPE).content(requestBody))
+          .andReturn().getResponse().getContentAsString();
+      ExerciseResponse actualExerciseResponse = mapper.readValue(actualResponseBody, ExerciseResponse.class);
+
+      assertThat(actualExerciseResponse).isNotNull()
+          .hasFieldOrPropertyWithValue("id", 1_000_000L)
+          .hasFieldOrPropertyWithValue("name", "Leg press")
+          .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
+          .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
+          .hasFieldOrPropertyWithValue("sets", 4)
+          .hasFieldOrPropertyWithValue("weight", 50.0)
+          .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:30:00"));
+      assertThat(actualExerciseResponse.updatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("addExercise must return status 400 when request body has invalid fields")
+    void addExercise_MustReturnStatus400_WhenRequestBodyHasInvalidFields() throws Exception {
+      String requestBody = """
+          {
+            "name": "Leg press",
+            "description": "   ",
+            "additional": "Apply the Rest in Pause technique in the last set",
+            "sets": 4,
+            "weight": 50.0
+          }
+          """;
+
+      mockMvc.perform(post(ADD_EXERCISE_URI, 1_000L).contentType(CONTENT_TYPE).content(requestBody))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("addExercise must return ProblemDetail when request body has invalid fields")
+    void addExercise_MustReturnProblemDetail_WhenRequestBodyHasInvalidFields() throws Exception {
+      String requestBody = """
+          {
+            "name": "Leg press",
+            "description": "   ",
+            "additional": "Apply the Rest in Pause technique in the last set",
+            "sets": 4,
+            "weight": 50.0
+          }
+          """;
+
+      String actualResponseBody = mockMvc.perform(post(ADD_EXERCISE_URI, 1_000L).contentType(CONTENT_TYPE).content(requestBody))
+          .andReturn().getResponse().getContentAsString();
+      ProblemDetail actualProblemDetail = mapper.readValue(actualResponseBody, ProblemDetail.class);
+
+      assertThat(actualProblemDetail).isNotNull()
+          .hasFieldOrPropertyWithValue("title", "Bad request")
+          .hasFieldOrPropertyWithValue("detail", "Some fields are invalid")
+          .hasFieldOrPropertyWithValue("status", 400);
+      assertThat(actualProblemDetail.getProperties()).isNotNull();
 
       String[] actualFields = ((String) actualProblemDetail.getProperties().get("fields")).split(";");
       String[] actualMessages = ((String) actualProblemDetail.getProperties().get("messages")).split(";");
 
       assertThat(actualFields).isNotNull().hasSize(1).contains("description");
       assertThat(actualMessages).isNotNull().hasSize(1).contains("description must be null or not be blank");
+    }
+
+    @Test
+    @DisplayName("addExercise must return status 404 when do not exists Workout with given id")
+    void addExercise_MustReturnStatus404_WhenDoNotExistsWorkoutWithGivenId() throws Exception {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(false);
+      String requestBody = """
+          {
+            "name": "Leg press",
+            "description": "Exercise that focuses on the quadriceps",
+            "additional": "Apply the Rest in Pause technique in the last set",
+            "sets": 4,
+            "weight": 50.0
+          }
+          """;
+
+      mockMvc.perform(post(ADD_EXERCISE_URI, 9_999L).contentType(CONTENT_TYPE).content(requestBody))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("addExercise must return ProblemDetail when do not exists Workout with given id")
+    void addExercise_MustReturnProblemDetail_WhenDoNotExistsWorkoutWithGivenId() throws Exception {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(false);
+      String requestBody = """
+          {
+            "name": "Leg press",
+            "description": "Exercise that focuses on the quadriceps",
+            "additional": "Apply the Rest in Pause technique in the last set",
+            "sets": 4,
+            "weight": 50.0
+          }
+          """;
+
+      String actualResponseBody = mockMvc.perform(post(ADD_EXERCISE_URI, 9_999L).contentType(CONTENT_TYPE).content(requestBody))
+          .andReturn().getResponse().getContentAsString();
+      ProblemDetail actualProblemDetail = mapper.readValue(actualResponseBody, ProblemDetail.class);
+
+      assertThat(actualProblemDetail).isNotNull()
+          .hasFieldOrPropertyWithValue("title", "Not found")
+          .hasFieldOrPropertyWithValue("detail", "workout not found with id: 9999")
+          .hasFieldOrPropertyWithValue("status", 404);
     }
 
   }

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/ExerciseCreateRequestTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/ExerciseCreateRequestTest.java
@@ -1,0 +1,328 @@
+package br.com.emendes.workout_tracker_api.unit.dto.request;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@DisplayName("Unit tests das validações do DTO ExerciseCreateRequest")
+class ExerciseCreateRequestTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Nested
+  @DisplayName("Tests for name validation")
+  class NameValidation {
+
+    public static final String NAME_PROPERTY = "name";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"A", "namewith100characters____namewith100characters____namewith100characters____namewith100characters____"})
+    @DisplayName("name validation must not return violations when name is valid")
+    void nameValidation_MustNotReturnViolations_WhenNameIsValid(String validName) {
+      assumeThat(validName).isNotBlank().hasSizeBetween(1, 100);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .name(validName)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, NAME_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"   ", "\t", "\n", ""})
+    @DisplayName("name validation must return violations when name is null or blank")
+    void nameValidation_MustReturnViolations_WhenNameIsNullOrBlank(String invalidName) {
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .name(invalidName)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, NAME_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("name must not be blank or null");
+    }
+
+    @Test
+    @DisplayName("name validation must return violations when name size is greater than 100")
+    void nameValidation_MustReturnViolations_WhenNameSizeIsGreaterThan100() {
+      String nameWithMoreThan100Characters = "nameWithMoreThan100Characters____nameWithMoreThan100Characters____nameWithMoreThan100Characters______";
+      assumeThat(nameWithMoreThan100Characters).isNotBlank().hasSizeGreaterThan(100);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .name(nameWithMoreThan100Characters)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, NAME_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("name must contain between 1 and 100 characters long");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Tests for description validation")
+  class DescriptionValidation {
+
+    private static final String DESCRIPTION_PROPERTY = "description";
+    public static final String DESCRIPTION_WITH_255_CHARACTERS_LONG =
+        "description with 255 characters long_____" +
+        "description with 255 characters long_____" +
+        "description with 255 characters long_____" +
+        "description with 255 characters long_____" +
+        "description with 255 characters long_____" +
+        "description with 255 characters long________";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"lorem ipsum dolor sit amet", DESCRIPTION_WITH_255_CHARACTERS_LONG})
+    @DisplayName("description validation must not return Violations when description is valid")
+    void descriptionValidation_MustNotReturnViolations_WhenDescriptionIsValid(String validDescription) {
+      assumeThat(validDescription).isNotNull().hasSizeLessThanOrEqualTo(255);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .description(validDescription)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, DESCRIPTION_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("description validation must not return Violations when description is NULL")
+    void descriptionValidation_MustNotReturnViolations_WhenDescriptionIsNull() {
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .description(null)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, DESCRIPTION_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"   ", "\t", "\n", ""})
+    @DisplayName("description validation must return Violations when description is blank")
+    void descriptionValidation_MustReturnViolations_WhenDescriptionIsBlank(String invalidDescription) {
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .description(invalidDescription)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, DESCRIPTION_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("description must be null or not be blank");
+    }
+
+    @Test
+    @DisplayName("description validation must return Violations when description size is greater than 255")
+    void descriptionValidation_MustReturnViolations_WhenDescriptionSizeIsGreaterThan255() {
+      String descriptionWith256CharactersLong =
+          "descriptionwith256characterslongdescriptionwith256characterslong" +
+          "descriptionwith256characterslongdescriptionwith256characterslong" +
+          "descriptionwith256characterslongdescriptionwith256characterslong" +
+          "descriptionwith256characterslongdescriptionwith256characterslong";
+      assumeThat(descriptionWith256CharactersLong).isNotNull().hasSize(256);
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .description(descriptionWith256CharactersLong)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, DESCRIPTION_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("description must contain max 255 characters long");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Tests for additional validation")
+  class AdditionalValidation {
+
+    private static final String ADDITIONAL_PROPERTY = "additional";
+    private static final String ADDITIONAL_WITH_150_CHARACTERS_LONG =
+        "additionalWith150CharactersLong______" +
+        "additionalWith150CharactersLong______" +
+        "additionalWith150CharactersLong______" +
+        "additionalWith150CharactersLong________";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"A", ADDITIONAL_WITH_150_CHARACTERS_LONG})
+    @DisplayName("additional validation must not return violations when name is valid")
+    void additionalValidation_MustNotReturnViolations_WhenNameIsValid(String validAdditional) {
+      assumeThat(validAdditional).isNotBlank().hasSizeBetween(1, 150);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .additional(validAdditional)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, ADDITIONAL_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("additional validation must not return Violations when additional is NULL")
+    void additionalValidation_MustNotReturnViolations_WhenAdditionalIsNull() {
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .additional(null)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, ADDITIONAL_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"   ", "\t", "\n", ""})
+    @DisplayName("additional validation must return Violations when additional is blank")
+    void additionalValidation_MustReturnViolations_WhenAdditionalIsBlank(String invalidAdditional) {
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .additional(invalidAdditional)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, ADDITIONAL_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("additional must be null or not be blank");
+    }
+
+    @Test
+    @DisplayName("additional validation must return Violations when additional size is greater than 255")
+    void additionalValidation_MustReturnViolations_WhenAdditionalSizeIsGreaterThan255() {
+      String additionalWith151CharactersLong =
+          "additionalWith151CharactersLong______" +
+          "additionalWith151CharactersLong______" +
+          "additionalWith151CharactersLong______" +
+          "additionalWith151CharactersLong_________";
+      assumeThat(additionalWith151CharactersLong).isNotNull().hasSize(151);
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .additional(additionalWith151CharactersLong)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, ADDITIONAL_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("additional must contain between 1 and 150 characters long");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Tests for sets validation")
+  class SetsValidation {
+
+    private static final String SETS_PROPERTY = "sets";
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 10, 1_000_000, Integer.MAX_VALUE})
+    @DisplayName("sets validation must not return Violations when sets is valid")
+    void setsValidation_MustNotReturnViolations_WhenSetsIsValid(int validSets) {
+      assumeThat(validSets).isBetween(1, Integer.MAX_VALUE);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .sets(validSets)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, SETS_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, -1_000_000, Integer.MIN_VALUE})
+    @DisplayName("sets validation must return Violations when sets is non positive")
+    void setsValidation_MustNotReturnViolations_WhenSetsIsNonPositive(int invalidSets) {
+      assumeThat(invalidSets).isLessThan(1);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .sets(invalidSets)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, SETS_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("sets must be positive");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Tests for weight validation")
+  class WeightValidation {
+
+    private static final String WEIGHT_PROPERTY = "weight";
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.5, 1.0, 1.5, 2.0, 10.0, 20.0, 25.0, 50.0})
+    @DisplayName("weight validation must not return Violations when weight is valid")
+    void weightValidation_MustNotReturnViolations_WhenWeightIsValid(double validWeight) {
+      assumeThat(validWeight).isPositive();
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .weight(validWeight)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, WEIGHT_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0, -0.5, -1.0, -10.0, -25.0})
+    @DisplayName("weight validation must return Violations when weight is non positive")
+    void weightValidation_MustNotReturnViolations_WhenWeightIsNonPositive(double invalidWeight) {
+      assumeThat(invalidWeight).isLessThan(1);
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .weight(invalidWeight)
+          .build();
+
+      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
+          .validateProperty(exerciseCreateRequest, WEIGHT_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("weight must be positive");
+    }
+
+  }
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/WorkoutCreateRequestTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/WorkoutCreateRequestTest.java
@@ -64,7 +64,7 @@ class WorkoutCreateRequestTest {
     @Test
     @DisplayName("name validation must return violations when name size is greater than 100")
     void nameValidation_MustReturnViolations_WhenNameSizeIsGreaterThan100() {
-      String nameWithMoreThan100Characters = "nameWith99CharactersLong_nameWith99CharactersLong_nameWith99CharactersLong_nameWith99CharactersLong__";
+      String nameWithMoreThan100Characters = "nameWithMoreThan100Characters____nameWithMoreThan100Characters____nameWithMoreThan100Characters______";
       assumeThat(nameWithMoreThan100Characters).isNotBlank().hasSizeGreaterThan(100);
 
       WorkoutCreateRequest workoutCreateRequest = WorkoutCreateRequest.builder()

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/ExerciseMapperImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/ExerciseMapperImplTest.java
@@ -1,0 +1,103 @@
+package br.com.emendes.workout_tracker_api.unit.mapper.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.mapper.impl.ExerciseMapperImpl;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Workout;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Unit tests for ExerciseMapperImpl")
+class ExerciseMapperImplTest {
+
+  private final ExerciseMapperImpl exerciseMapper = new ExerciseMapperImpl();
+
+  @Test
+  @DisplayName("toExercise must return Exercise when map successfully")
+  void toExercise_MustReturnExercise_WhenMapSuccessfully() {
+    ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+        .name("Leg press")
+        .description("Exercise that focuses on the quadriceps")
+        .additional("Apply the Rest in Pause technique in the last set")
+        .sets(4)
+        .weight(50.0)
+        .build();
+    Exercise actualExercise = exerciseMapper.toExercise(1_000L, exerciseCreateRequest);
+
+    assertThat(actualExercise).isNotNull()
+        .hasFieldOrPropertyWithValue("name", "Leg press")
+        .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
+        .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
+        .hasFieldOrPropertyWithValue("sets", 4)
+        .hasFieldOrPropertyWithValue("weight", 50.0);
+    assertThat(actualExercise.getId()).isNull();
+    assertThat(actualExercise.getCreatedAt()).isNotNull();
+    assertThat(actualExercise.getWorkout()).isNotNull()
+        .hasFieldOrPropertyWithValue("id", 1_000L);
+  }
+
+  @Test
+  @DisplayName("toExercise must throw IllegalArgumentException when exerciseCreateRequest is null")
+  void toExercise_MustThrowIllegalArgumentException_WhenExerciseCreateRequestIsNull() {
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> exerciseMapper.toExercise(1_000L, null))
+        .withMessage("exerciseCreateRequest must not be null");
+  }
+
+  @Test
+  @DisplayName("toExercise must throw IllegalArgumentException when workoutId is null")
+  void toExercise_MustThrowIllegalArgumentException_WhenWorkoutIdIsNull() {
+    ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+        .name("Leg press")
+        .description("Exercise that focuses on the quadriceps")
+        .additional("Apply the Rest in Pause technique in the last set")
+        .sets(4)
+        .weight(50.0)
+        .build();
+
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> exerciseMapper.toExercise(null, exerciseCreateRequest))
+        .withMessage("workoutId must not be null");
+  }
+
+  @Test
+  @DisplayName("toExerciseResponse must return Exercise when map successfully")
+  void toExerciseResponse_MustReturnExercise_WhenMapSuccessfully() {
+    Exercise exercise = Exercise.builder()
+        .id(1_000_000L)
+        .name("Leg press")
+        .description("Exercise that focuses on the quadriceps")
+        .additional("Apply the Rest in Pause technique in the last set")
+        .sets(4)
+        .weight(50.0)
+        .createdAt(LocalDateTime.parse("2025-05-12T10:00:00"))
+        .workout(Workout.builder().id(1_000L).build())
+        .build();
+    ExerciseResponse actualExerciseResponse = exerciseMapper.toExerciseResponse(exercise);
+
+    assertThat(actualExerciseResponse).isNotNull()
+        .hasFieldOrPropertyWithValue("id", 1_000_000L)
+        .hasFieldOrPropertyWithValue("name", "Leg press")
+        .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
+        .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
+        .hasFieldOrPropertyWithValue("sets", 4)
+        .hasFieldOrPropertyWithValue("weight", 50.0)
+        .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:00:00"))
+        .hasFieldOrPropertyWithValue("updatedAt", null);
+  }
+
+  @Test
+  @DisplayName("toExerciseResponse must throw IllegalArgumentException when exercise is null")
+  void toExerciseResponse_MustThrowIllegalArgumentException_WhenExerciseIsNull() {
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> exerciseMapper.toExerciseResponse(null))
+        .withMessage("exercise must not be null");
+  }
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/WorkoutMapperImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/WorkoutMapperImplTest.java
@@ -63,8 +63,8 @@ class WorkoutMapperImplTest {
   }
 
   @Test
-  @DisplayName("toWorkoutResponse must throw IllegalArgumentException when workoutCreateRequest is null")
-  void toWorkoutResponse_MustThrowIllegalArgumentException_WhenWorkoutCreateRequestIsNull() {
+  @DisplayName("toWorkoutResponse must throw IllegalArgumentException when workout is null")
+  void toWorkoutResponse_MustThrowIllegalArgumentException_WhenWorkoutIsNull() {
     Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> workoutMapper.toWorkoutResponse(null))
         .withMessage("workout must not be null");

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/ExerciseServiceImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/ExerciseServiceImplTest.java
@@ -1,0 +1,69 @@
+package br.com.emendes.workout_tracker_api.unit.service.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.mapper.ExerciseMapper;
+import br.com.emendes.workout_tracker_api.repository.ExerciseRepository;
+import br.com.emendes.workout_tracker_api.service.impl.ExerciseServiceImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+
+import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("Unit tests for ExerciseServiceImpl")
+class ExerciseServiceImplTest {
+
+  @InjectMocks
+  private ExerciseServiceImpl exerciseService;
+  @Mock
+  private ExerciseMapper exerciseMapperMock;
+  @Mock
+  private ExerciseRepository exerciseRepositoryMock;
+
+  @Nested
+  @DisplayName("Create Method")
+  class CreateMethod {
+
+    @Test
+    @DisplayName("create must return ExerciseResponse when create successfully")
+    void create_MustReturnExerciseResponse_WhenCreateSuccessfully() {
+      when(exerciseMapperMock.toExercise(any(), any())).thenReturn(nonCreatedExercise());
+      when(exerciseRepositoryMock.save(any())).thenReturn(exercise());
+      when(exerciseMapperMock.toExerciseResponse(any())).thenReturn(exerciseResponse());
+
+      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
+          .name("Leg press")
+          .description("Exercise that focuses on the quadriceps")
+          .additional("Apply the Rest in Pause technique in the last set")
+          .sets(4)
+          .weight(50.0)
+          .build();
+
+      ExerciseResponse actualExerciseResponse = exerciseService.create(1_000L, exerciseCreateRequest);
+
+      Assertions.assertThat(actualExerciseResponse).isNotNull()
+          .hasFieldOrPropertyWithValue("name", "Leg press")
+          .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
+          .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
+          .hasFieldOrPropertyWithValue("sets", 4)
+          .hasFieldOrPropertyWithValue("weight", 50.0)
+          .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:30:00"));
+      assertThat(actualExerciseResponse.id()).isNotNull();
+      assertThat(actualExerciseResponse.updatedAt()).isNull();
+    }
+
+  }
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/faker/ExerciseFaker.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/faker/ExerciseFaker.java
@@ -1,0 +1,72 @@
+package br.com.emendes.workout_tracker_api.util.faker;
+
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+
+import java.time.LocalDateTime;
+
+import static br.com.emendes.workout_tracker_api.util.faker.WorkoutFaker.workout;
+
+/**
+ * Classe utilitária que gera objetos relacionados a Workout para uso em testes automatizados.
+ */
+public class ExerciseFaker {
+
+  public static final long EXERCISE_ID = 1_000_000L;
+  public static final String EXERCISE_NAME = "Leg press";
+  public static final String EXERCISE_DESCRIPTION = "Exercise that focuses on the quadriceps";
+  public static final String EXERCISE_ADDITIONAL = "Apply the Rest in Pause technique in the last set";
+  public static final int EXERCISE_SETS = 4;
+  public static final double EXERCISE_WEIGHT = 50.0;
+  public static final LocalDateTime EXERCISE_CREATED_AT = LocalDateTime.parse("2025-05-12T10:30:00");
+
+  private ExerciseFaker() {
+  }
+
+  /**
+   * Cria um objeto ExerciseResponse com todos os campos.
+   */
+  public static ExerciseResponse exerciseResponse() {
+    return ExerciseResponse.builder()
+        .id(EXERCISE_ID)
+        .name(EXERCISE_NAME)
+        .description(EXERCISE_DESCRIPTION)
+        .additional(EXERCISE_ADDITIONAL)
+        .sets(EXERCISE_SETS)
+        .weight(EXERCISE_WEIGHT)
+        .createdAt(EXERCISE_CREATED_AT)
+        .build();
+  }
+
+  /**
+   * Cria um objeto Exercise sem id e updatedAt e com os campos name, description,
+   * additional, sets, weight, workout e createdAt.
+   */
+  public static Exercise nonCreatedExercise() {
+    return Exercise.builder()
+        .name(EXERCISE_NAME)
+        .description(EXERCISE_DESCRIPTION)
+        .additional(EXERCISE_ADDITIONAL)
+        .sets(EXERCISE_SETS)
+        .weight(EXERCISE_WEIGHT)
+        .createdAt(EXERCISE_CREATED_AT)
+        .workout(workout())
+        .build();
+  }
+
+  /**
+   * Cria um objeto Exercise com todos os campos (exceto updateAt).
+   */
+  public static Exercise exercise() {
+    return Exercise.builder()
+        .id(EXERCISE_ID)
+        .name(EXERCISE_NAME)
+        .description(EXERCISE_DESCRIPTION)
+        .additional(EXERCISE_ADDITIONAL)
+        .sets(EXERCISE_SETS)
+        .weight(EXERCISE_WEIGHT)
+        .createdAt(EXERCISE_CREATED_AT)
+        .workout(workout())
+        .build();
+  }
+}


### PR DESCRIPTION
- add entity exercise
- add interface ExerciseRepository
- add interface ExerciseService
- add implementação de ExerciseService
- add implementação de ExerciseMapper
- add WorkoutService.addExercise
- add WorkoutController.addExercise
- add ExerciseMapperImpl unit tests
- add ExerciseCreateRequest unit tests
- add WorkoutServiceImpl.addExercise unit tests
- add ExerciseServiceImpl unit tests
- add integration tests para o endpoint POST /api/v1/workouts/{workoutId}/exercises