### PR TITLE
feat: add endpoint para adicionar uma carga ao exercício

### DIFF
--- a/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
@@ -1,8 +1,10 @@
 package br.com.emendes.workout_tracker_api.controller;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.service.WorkoutService;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +57,27 @@ public class WorkoutController {
         .build(workoutId, exerciseResponse.id());
 
     return ResponseEntity.created(location).body(exerciseResponse);
+  }
+
+  /**
+   * Método responsável pelo endpoint POST /api/v1/workouts/{workoutId}/exercises/{exerciseId}/weights
+   * para adicionar o recurso Weight ao Exercise.
+   *
+   * @param workoutId             identificador do Workout que receberá o Exercise.
+   * @param exerciseCreateRequest objeto contendo as informações do Exercise que será adicionado.
+   * @param uriBuilder            objeto que mantém o host do endpoint para construção do header location.
+   */
+  @PostMapping("/{workoutId}/exercises/{exerciseId}/weights")
+  ResponseEntity<WeightResponse> addWeight(
+      @PathVariable("workoutId") Long workoutId,
+      @PathVariable("exerciseId") Long exerciseId,
+      @RequestBody WeightCreateRequest weightCreateRequest,
+      UriComponentsBuilder uriBuilder) {
+    WeightResponse weightResponse = workoutService.addWeight(workoutId, exerciseId, weightCreateRequest);
+    URI location = uriBuilder.path("/{workoutId}/exercises/{exerciseId}/weights/{weightId}")
+        .build(workoutId, exerciseId, weightResponse.id());
+
+    return ResponseEntity.created(location).body(weightResponse);
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/request/ExerciseCreateRequest.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/request/ExerciseCreateRequest.java
@@ -13,7 +13,6 @@ import lombok.Builder;
  * @param description descrição do Exercise (não obrigatório).
  * @param additional  informação adicional do Exercise (não obrigatório).
  * @param sets        número de sets do Exercise.
- * @param weight      carga usado no Exercise.
  */
 @Builder
 public record ExerciseCreateRequest(
@@ -27,8 +26,6 @@ public record ExerciseCreateRequest(
     @Size(min = 1, max = 150, message = "additional must contain between {min} and {max} characters long")
     String additional,
     @Positive(message = "sets must be positive")
-    int sets,
-    @Positive(message = "weight must be positive")
-    double weight
+    int sets
 ) {
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/request/WeightCreateRequest.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/request/WeightCreateRequest.java
@@ -1,0 +1,23 @@
+package br.com.emendes.workout_tracker_api.dto.request;
+
+import br.com.emendes.workout_tracker_api.validation.annotation.ValidUnitOfMeasurement;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+/**
+ * Record DTO com os dados para criação de Weight.
+ *
+ * @param value valor do Weight.
+ * @param unit  unidade de medida em que está o value, pode ser KILOGRAMS, POUNDS, HOURS ou MINUTES.
+ */
+@Builder
+public record WeightCreateRequest(
+    @Digits(integer = 4, fraction = 1, message = "value is out of bounds (<{integer} digits>.<{fraction} digits>)")
+    @NotBlank(message = "value must not be blank")
+    String value,
+    @NotBlank(message = "unit must not be blank")
+    @ValidUnitOfMeasurement(message = "unit must be a valid unit of measurement (i.e. KILOGRAM, POUNDS, HOURS, MINUTES")
+    String unit
+) {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/response/ExerciseResponse.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/response/ExerciseResponse.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
  * @param description descrição do Exercise.
  * @param additional  informações adicionais do Exercise.
  * @param sets        número de séries do Exercise.
- * @param weight      peso do Exercise.
  * @param createdAt   data de criação do Exercise.
  * @param updatedAt   data de atualização do Exercise.
  */
@@ -23,7 +22,6 @@ public record ExerciseResponse(
     String description,
     String additional,
     int sets,
-    double weight,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/response/WeightResponse.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/response/WeightResponse.java
@@ -1,0 +1,22 @@
+package br.com.emendes.workout_tracker_api.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * Record DTO com os dados de Weight.
+ *
+ * @param id        identificador do Weight
+ * @param value     valor de Weight
+ * @param unit      unidade de medida em que está o value
+ * @param createdAt data de criação de Weight
+ */
+@Builder
+public record WeightResponse(
+    Long id,
+    String value,
+    String unit,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/exception/ExerciseNotFoundException.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/exception/ExerciseNotFoundException.java
@@ -1,0 +1,11 @@
+package br.com.emendes.workout_tracker_api.exception;
+
+/**
+ * Exception para ser lançada em caso de Exercise não encontrado.
+ */
+public class ExerciseNotFoundException extends RuntimeException {
+
+  public ExerciseNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/handler/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.emendes.workout_tracker_api.handler;
 
+import br.com.emendes.workout_tracker_api.exception.ExerciseNotFoundException;
 import br.com.emendes.workout_tracker_api.exception.WorkoutNotFoundException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -44,6 +45,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(WorkoutNotFoundException.class)
   public ResponseEntity<ProblemDetail> handleWorkoutNotFound(WorkoutNotFoundException exception) {
+    ProblemDetail problemDetail = ProblemDetail.forStatus(404);
+    problemDetail.setTitle("Not found");
+    problemDetail.setDetail(exception.getMessage());
+    problemDetail.setType(URI.create("https://github.com/Edson-Mendes/workout-tracker-api"));
+
+    return ResponseEntity.status(404).body(problemDetail);
+  }
+
+  @ExceptionHandler(ExerciseNotFoundException.class)
+  public ResponseEntity<ProblemDetail> handleExerciseNotFound(ExerciseNotFoundException exception) {
     ProblemDetail problemDetail = ProblemDetail.forStatus(404);
     problemDetail.setTitle("Not found");
     problemDetail.setDetail(exception.getMessage());

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/WeightMapper.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/WeightMapper.java
@@ -1,0 +1,31 @@
+package br.com.emendes.workout_tracker_api.mapper;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
+
+/**
+ * Interface com as abstrações para mapeamento de do recurso Weight.
+ */
+public interface WeightMapper {
+
+  /**
+   * Mapeia um objeto {@link WeightCreateRequest} para {@link Weight}.<br>
+   * <br>
+   * O campo {@code Weight.createdAt} tem o valor padrão o horário de criação de Weight.
+   *
+   * @param exerciseId          identificador do Exercise relacionado com o Weight.
+   * @param weightCreateRequest objeto contendo os dados de criação de Weight
+   * @return Weight com os dados de weightCreateRequest.
+   */
+  Weight toWeight(Long exerciseId, WeightCreateRequest weightCreateRequest);
+
+  /**
+   * Mapeia um objeto {@link Weight} para {@link WeightResponse}.
+   *
+   * @param weight objeto que será mapeado.
+   * @return {@code WeightResponse} com as informações de Weight.
+   */
+  WeightResponse toWeightResponse(Weight weight);
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/ExerciseMapperImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/ExerciseMapperImpl.java
@@ -26,7 +26,6 @@ public class ExerciseMapperImpl implements ExerciseMapper {
         .description(exerciseCreateRequest.description())
         .additional(exerciseCreateRequest.additional())
         .sets(exerciseCreateRequest.sets())
-        .weight(exerciseCreateRequest.weight())
         .createdAt(LocalDateTime.now())
         .workout(Workout.builder().id(workoutId).build())
         .build();
@@ -42,7 +41,6 @@ public class ExerciseMapperImpl implements ExerciseMapper {
         .description(exercise.getDescription())
         .additional(exercise.getAdditional())
         .sets(exercise.getSets())
-        .weight(exercise.getWeight())
         .createdAt(exercise.getCreatedAt())
         .updatedAt(exercise.getUpdatedAt())
         .build();

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/WeightMapperImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/WeightMapperImpl.java
@@ -1,0 +1,46 @@
+package br.com.emendes.workout_tracker_api.mapper.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.mapper.WeightMapper;
+import br.com.emendes.workout_tracker_api.model.UnitOfMeasurement;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Implementação de {@link WeightMapper}.
+ */
+@Component
+public class WeightMapperImpl implements WeightMapper {
+
+  @Override
+  public Weight toWeight(Long exerciseId, WeightCreateRequest weightCreateRequest) {
+    Assert.notNull(exerciseId, "exerciseId must not be null");
+    Assert.notNull(weightCreateRequest, "weightCreateRequest must not be null");
+
+    return Weight.builder()
+        .value(new BigDecimal(weightCreateRequest.value()))
+        .unit(UnitOfMeasurement.valueOf(weightCreateRequest.unit()))
+        .createdAt(LocalDateTime.now())
+        .exercise(Exercise.builder().id(exerciseId).build())
+        .build();
+  }
+
+  @Override
+  public WeightResponse toWeightResponse(Weight weight) {
+    Assert.notNull(weight, "weight must not be null");
+
+    return WeightResponse.builder()
+        .id(weight.getId())
+        .value(weight.getValue().toString())
+        .unit(weight.getUnit().toString())
+        .createdAt(weight.getCreatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/UnitOfMeasurement.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/UnitOfMeasurement.java
@@ -1,0 +1,11 @@
+package br.com.emendes.workout_tracker_api.model;
+
+/**
+ * Enum para indicar as unidades de medida das cargas.
+ */
+public enum UnitOfMeasurement {
+  KILOGRAMS,
+  POUNDS,
+  MINUTES,
+  HOURS
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Exercise.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Exercise.java
@@ -31,13 +31,13 @@ public class Exercise {
   private String additional;
   @Column(name = "sets", nullable = false)
   private int sets;
-  @Column(name = "weight", nullable = false)
-  private double weight;
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private Workout workout;
+  @OneToOne(fetch = FetchType.LAZY)
+  private Weight weight;
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Weight.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Weight.java
@@ -1,0 +1,37 @@
+package br.com.emendes.workout_tracker_api.model.entity;
+
+import br.com.emendes.workout_tracker_api.model.UnitOfMeasurement;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Classe que representa a entidade Weight do banco de dados.
+ */
+@Entity
+@Table(name = "tb_weight")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Weight {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+  @Column(name = "value", nullable = false, precision = 5, scale = 1)
+  private BigDecimal value;
+  @Column(name = "unit", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private UnitOfMeasurement unit;
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  private Exercise exercise;
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/repository/WeightRepository.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/repository/WeightRepository.java
@@ -1,0 +1,10 @@
+package br.com.emendes.workout_tracker_api.repository;
+
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Interface repository com as abstrações para interação com o recurso Weight no banco de dados.
+ */
+public interface WeightRepository extends JpaRepository<Weight, Long> {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/ExerciseService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/ExerciseService.java
@@ -1,7 +1,10 @@
 package br.com.emendes.workout_tracker_api.service;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Interface com as abstrações para manipulação do recurso Exercise.
@@ -16,5 +19,16 @@ public interface ExerciseService {
    * @return ExerciseResponse contendo as informações do Exercise criado.
    */
   ExerciseResponse create(Long workoutId, ExerciseCreateRequest exerciseCreateRequest);
+
+  /**
+   * Adicionar um Weight ao Exercise.
+   *
+   * @param exerciseId          identificador do Exercise.
+   * @param weightCreateRequest objeto contendo os dados para adicionar um Weight.
+   * @return WeightResponse objeto com as informações do Weight adicionado.
+   */
+  WeightResponse addWeight(
+      @NotNull(message = "exerciseId must not be null") Long exerciseId,
+      WeightCreateRequest weightCreateRequest);
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/WeightService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/WeightService.java
@@ -1,0 +1,26 @@
+package br.com.emendes.workout_tracker_api.service;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Interface com as abstrações para manipulação do recurso Weight.
+ */
+@Validated
+public interface WeightService {
+
+  /**
+   * Cria um Weight.
+   *
+   * @param exerciseId          identificador do Exercise relacionado com Weight.
+   * @param weightCreateRequest objeto contendo os dados para criação do Weight
+   * @return {@code WeightResponse} contendo as informações do Weight criado.
+   */
+  WeightResponse create(
+      @NotNull(message = "exerciseId must not be null") Long exerciseId,
+      @Valid WeightCreateRequest weightCreateRequest);
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
@@ -1,8 +1,10 @@
 package br.com.emendes.workout_tracker_api.service;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -32,5 +34,18 @@ public interface WorkoutService {
   ExerciseResponse addExercise(
       @NotNull(message = "workoutId must not be null") Long workoutId,
       @Valid ExerciseCreateRequest exerciseCreateRequest);
+
+  /**
+   * Adiciona um Weight ao Exercise que pertence ao Workout com id workoutId.
+   *
+   * @param workoutId           identificador do Workout.
+   * @param exerciseId          identificador do Exercise.
+   * @param weightCreateRequest objeto contendo os dados de criação de Weight.
+   * @return WeightResponse contento as informações do Weight adicionado.
+   */
+  WeightResponse addWeight(
+      @NotNull(message = "workoutId must not be null") Long workoutId,
+      Long exerciseId,
+      WeightCreateRequest weightCreateRequest);
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/ExerciseServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/ExerciseServiceImpl.java
@@ -1,14 +1,21 @@
 package br.com.emendes.workout_tracker_api.service.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.exception.ExerciseNotFoundException;
 import br.com.emendes.workout_tracker_api.mapper.ExerciseMapper;
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
 import br.com.emendes.workout_tracker_api.repository.ExerciseRepository;
 import br.com.emendes.workout_tracker_api.service.ExerciseService;
+import br.com.emendes.workout_tracker_api.service.WeightService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 /**
  * Implementação de {@link ExerciseService}.
@@ -20,6 +27,7 @@ public class ExerciseServiceImpl implements ExerciseService {
 
   private final ExerciseMapper exerciseMapper;
   private final ExerciseRepository exerciseRepository;
+  private final WeightService weightService;
 
   @Override
   public ExerciseResponse create(Long workoutId, ExerciseCreateRequest exerciseCreateRequest) {
@@ -29,6 +37,23 @@ public class ExerciseServiceImpl implements ExerciseService {
     log.info("exercise created successfully with id: {}", exercise.getId());
 
     return exerciseMapper.toExerciseResponse(exercise);
+  }
+
+  @Override
+  public WeightResponse addWeight(Long exerciseId, WeightCreateRequest weightCreateRequest) {
+    log.info("attempt to add Weight to exercise with id: {}", exerciseId);
+    Optional<Exercise> exerciseOptional = exerciseRepository.findById(exerciseId);
+    if (exerciseOptional.isPresent()) {
+      WeightResponse weightResponse = weightService.create(exerciseId, weightCreateRequest);
+      Exercise exercise = exerciseOptional.get();
+      exercise.setWeight(Weight.builder().id(weightResponse.id()).build());
+      exerciseRepository.save(exercise);
+      log.info("weight with id: {} added successfully into exercise with id: {}", weightResponse.id(), exerciseId);
+
+      return weightResponse;
+    }
+
+    throw new ExerciseNotFoundException("exercise not found with id: %s".formatted(exerciseId));
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WeightServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WeightServiceImpl.java
@@ -1,0 +1,34 @@
+package br.com.emendes.workout_tracker_api.service.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.mapper.WeightMapper;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
+import br.com.emendes.workout_tracker_api.repository.WeightRepository;
+import br.com.emendes.workout_tracker_api.service.WeightService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementação de {@link WeightService}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WeightServiceImpl implements WeightService {
+
+  private final WeightMapper weightMapper;
+  private final WeightRepository weightRepository;
+
+  @Override
+  public WeightResponse create(Long exerciseId, WeightCreateRequest weightCreateRequest) {
+    log.info("attempt to create weight");
+    Weight weight = weightMapper.toWeight(exerciseId, weightCreateRequest);
+
+    weight = weightRepository.save(weight);
+    log.info("weight created successfully with id: {}", weight.getId());
+    return weightMapper.toWeightResponse(weight);
+  }
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
@@ -1,8 +1,10 @@
 package br.com.emendes.workout_tracker_api.service.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.exception.WorkoutNotFoundException;
 import br.com.emendes.workout_tracker_api.mapper.WorkoutMapper;
@@ -38,15 +40,34 @@ public class WorkoutServiceImpl implements WorkoutService {
 
   @Override
   public ExerciseResponse addExercise(Long workoutId, ExerciseCreateRequest exerciseCreateRequest) {
-    log.info("attempt to add Exercise to workout with id: {}", workoutId);
-    if (workoutRepository.existsById(workoutId)) {
-      ExerciseResponse exerciseResponse = exerciseService.create(workoutId, exerciseCreateRequest);
+    log.info("attempt to add exercise to workout with id: {}", workoutId);
+    verifyIfExistsWorkout(workoutId);
 
-      log.info("exercise added successfully with id: {}", exerciseResponse.id());
-      return exerciseResponse;
-    }
+    ExerciseResponse exerciseResponse = exerciseService.create(workoutId, exerciseCreateRequest);
+    log.info("exercise added successfully with id: {}", exerciseResponse.id());
+    return exerciseResponse;
+  }
 
-    throw new WorkoutNotFoundException("workout not found with id: %s".formatted(workoutId));
+  @Override
+  public WeightResponse addWeight(Long workoutId, Long exerciseId, WeightCreateRequest weightCreateRequest) {
+    log.info("attempt to add weight to the exercise belonging to workout with id: {}", workoutId);
+    verifyIfExistsWorkout(workoutId);
+
+    return exerciseService.addWeight(exerciseId, weightCreateRequest);
+
+  }
+
+  /**
+   * Verifica se existe Workout para o dado workoutId.
+   * Caso exista Workout, o programa segue o fluxo normal, caso contrário,
+   * {@code WorkoutNotFoundException} é lançada.
+   *
+   * @param workoutId identificador do workout a ser verificado.
+   * @throws WorkoutNotFoundException caso não exista Workout para o dado workoutId.
+   */
+  private void verifyIfExistsWorkout(Long workoutId) {
+    if (!workoutRepository.existsById(workoutId))
+      throw new WorkoutNotFoundException("workout not found with id: %s".formatted(workoutId));
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/validation/annotation/ValidUnitOfMeasurement.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/validation/annotation/ValidUnitOfMeasurement.java
@@ -1,0 +1,32 @@
+package br.com.emendes.workout_tracker_api.validation.annotation;
+
+import br.com.emendes.workout_tracker_api.validation.validator.UnitOfMeasurementValidator;
+import jakarta.validation.Constraint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Verifica se o elemento anotado é uma unidade de medida.<br>
+ * <br>
+ * Unidades válidas: KILOGRAMS, POUNDS, HOURS, MINUTES.<br>
+ * Letras minúsculas também são aceitas (i.e. Kilograms, KiLoGrAms são valores válidos)
+ * <br><br>
+ * Suporta tipo String.
+ * <br><br>
+ * Elementos {@code null} são considerados válidos.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UnitOfMeasurementValidator.class)
+public @interface ValidUnitOfMeasurement {
+
+  String message() default "must be a valid unit of measurement";
+
+  Class<?>[] groups() default {};
+
+  Class<?>[] payload() default {};
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/validation/validator/UnitOfMeasurementValidator.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/validation/validator/UnitOfMeasurementValidator.java
@@ -1,0 +1,24 @@
+package br.com.emendes.workout_tracker_api.validation.validator;
+
+import br.com.emendes.workout_tracker_api.model.UnitOfMeasurement;
+import br.com.emendes.workout_tracker_api.validation.annotation.ValidUnitOfMeasurement;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validator de {@link ValidUnitOfMeasurement}.
+ */
+public class UnitOfMeasurementValidator implements ConstraintValidator<ValidUnitOfMeasurement, String> {
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) return true;
+    try {
+      UnitOfMeasurement.valueOf(value.toUpperCase());
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+}

--- a/src/main/resources/db/migration/V02__CREATE_TABLE_EXERCISE.sql
+++ b/src/main/resources/db/migration/V02__CREATE_TABLE_EXERCISE.sql
@@ -4,7 +4,6 @@ CREATE TABLE tb_exercise (
     description varchar(255) NULL,
     additional varchar(150) NULL,
     sets int NOT NULL,
-    weight real NOT NULL,
     created_at timestamp NOT NULL,
     updated_at timestamp NULL,
     workout_id bigint NOT NULL,

--- a/src/main/resources/db/migration/V03__CREATE_TABLE_WEIGHT.sql
+++ b/src/main/resources/db/migration/V03__CREATE_TABLE_WEIGHT.sql
@@ -1,0 +1,9 @@
+CREATE TABLE tb_weight (
+    id bigserial NOT NULL,
+    value numeric(5, 1) NOT NULL,
+    unit varchar(50) NOT NULL,
+    created_at timestamp NOT NULL,
+    exercise_id bigint NULL,
+    CONSTRAINT tb_weight__f_id__pk PRIMARY KEY (id),
+    CONSTRAINT tb_weight__f_exercise_id__fk FOREIGN KEY (exercise_id) REFERENCES tb_exercise(id)
+);

--- a/src/main/resources/db/migration/V04__UPDATE_TABLE_EXERCISE.sql
+++ b/src/main/resources/db/migration/V04__UPDATE_TABLE_EXERCISE.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_exercise ADD weight_id bigint;
+ALTER TABLE tb_exercise ADD CONSTRAINT tb_exercise__f_weight_id__fk FOREIGN KEY (weight_id) REFERENCES tb_weight(id);

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/ExerciseCreateRequestTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/ExerciseCreateRequestTest.java
@@ -283,46 +283,4 @@ class ExerciseCreateRequestTest {
 
   }
 
-  @Nested
-  @DisplayName("Tests for weight validation")
-  class WeightValidation {
-
-    private static final String WEIGHT_PROPERTY = "weight";
-
-    @ParameterizedTest
-    @ValueSource(doubles = {0.5, 1.0, 1.5, 2.0, 10.0, 20.0, 25.0, 50.0})
-    @DisplayName("weight validation must not return Violations when weight is valid")
-    void weightValidation_MustNotReturnViolations_WhenWeightIsValid(double validWeight) {
-      assumeThat(validWeight).isPositive();
-
-      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
-          .weight(validWeight)
-          .build();
-
-      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
-          .validateProperty(exerciseCreateRequest, WEIGHT_PROPERTY);
-
-      assertThat(actualViolations).isNotNull().isEmpty();
-    }
-
-    @ParameterizedTest
-    @ValueSource(doubles = {0, -0.5, -1.0, -10.0, -25.0})
-    @DisplayName("weight validation must return Violations when weight is non positive")
-    void weightValidation_MustNotReturnViolations_WhenWeightIsNonPositive(double invalidWeight) {
-      assumeThat(invalidWeight).isLessThan(1);
-
-      ExerciseCreateRequest exerciseCreateRequest = ExerciseCreateRequest.builder()
-          .weight(invalidWeight)
-          .build();
-
-      Set<ConstraintViolation<ExerciseCreateRequest>> actualViolations = validator
-          .validateProperty(exerciseCreateRequest, WEIGHT_PROPERTY);
-
-      assertThat(actualViolations).isNotNull().isNotEmpty();
-      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
-      assertThat(actualMessages).isNotNull().contains("weight must be positive");
-    }
-
-  }
-
 }

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/WeightCreateRequestTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/dto/request/WeightCreateRequestTest.java
@@ -1,0 +1,148 @@
+package br.com.emendes.workout_tracker_api.unit.dto.request;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Unit tests das validações do DTO WeightCreateRequest")
+class WeightCreateRequestTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Nested
+  @DisplayName("Tests for value validation")
+  class ValueValidation {
+
+    private final String VALUE_PROPERTY = "value";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "10", "100", "1000", "1.5", "10.5", "100.5", "1000.5"})
+    @DisplayName("value validation must not return Violations when value is valid")
+    void valueValidation_MustNotReturnViolations_WhenValueIsValid(String validValue) {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value(validValue)
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, VALUE_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("value validation must return Violations when integer part has more than 4 digits")
+    void valueValidation_MustReturnViolations_WhenIntegerPartHasMoreThan4Digits() {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value("10000")
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, VALUE_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("value is out of bounds (<4 digits>.<1 digits>)");
+    }
+
+    @Test
+    @DisplayName("value validation must return Violations when fraction part has more than 1 digits")
+    void valueValidation_MustReturnViolations_WhenFractionPartHasMoreThan1Digits() {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value("0.15")
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, VALUE_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("value is out of bounds (<4 digits>.<1 digits>)");
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"   ", "\t", "\n", ""})
+    @DisplayName("value validation must return Violations when value is Null or blank")
+    void valueValidation_MustReturnViolations_WhenValueIsNullOrBlank(String blankValue) {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value(blankValue)
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, VALUE_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("value must not be blank");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Tests for unit validation")
+  class UnitValidation {
+
+    private final String UNIT_PROPERTY = "unit";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"KILOGRAMS", "Kilograms", "KiLoGrAmS", "POUNDS", "HOURS", "minutes"})
+    @DisplayName("unit validation must not return Violations when unit is valid")
+    void unitValidation_MustNotReturnViolations_WhenUnitIsValid(String validUnit) {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .unit(validUnit)
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, UNIT_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"   ", "\t", "\n", ""})
+    @NullSource
+    @DisplayName("unit validation must return Violations when unit is blank")
+    void unitValidation_MustReturnViolations_WhenUnitIsBlank(String blankUnit) {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .unit(blankUnit)
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, UNIT_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("unit must not be blank");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"KILOGRAm", "lorem", "K I L O G R A M S", "K ilograms"})
+    @DisplayName("unit validation must return Violations when unit is not a valid unit of measurement")
+    void unitValidation_MustReturnViolations_WhenUnitIsNotAValidUnitOfMeasurement(String invalidUnit) {
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .unit(invalidUnit)
+          .build();
+
+      Set<ConstraintViolation<WeightCreateRequest>> actualViolations = validator
+          .validateProperty(weightCreateRequest, UNIT_PROPERTY);
+
+      assertThat(actualViolations).isNotNull().isNotEmpty();
+      List<String> actualMessages = actualViolations.stream().map(ConstraintViolation::getMessage).toList();
+      assertThat(actualMessages).isNotNull().contains("unit must be a valid unit of measurement (i.e. KILOGRAM, POUNDS, HOURS, MINUTES");
+    }
+
+  }
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/ExerciseMapperImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/ExerciseMapperImplTest.java
@@ -26,7 +26,6 @@ class ExerciseMapperImplTest {
         .description("Exercise that focuses on the quadriceps")
         .additional("Apply the Rest in Pause technique in the last set")
         .sets(4)
-        .weight(50.0)
         .build();
     Exercise actualExercise = exerciseMapper.toExercise(1_000L, exerciseCreateRequest);
 
@@ -34,8 +33,7 @@ class ExerciseMapperImplTest {
         .hasFieldOrPropertyWithValue("name", "Leg press")
         .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
         .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
-        .hasFieldOrPropertyWithValue("sets", 4)
-        .hasFieldOrPropertyWithValue("weight", 50.0);
+        .hasFieldOrPropertyWithValue("sets", 4);
     assertThat(actualExercise.getId()).isNull();
     assertThat(actualExercise.getCreatedAt()).isNotNull();
     assertThat(actualExercise.getWorkout()).isNotNull()
@@ -58,7 +56,6 @@ class ExerciseMapperImplTest {
         .description("Exercise that focuses on the quadriceps")
         .additional("Apply the Rest in Pause technique in the last set")
         .sets(4)
-        .weight(50.0)
         .build();
 
     Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
@@ -75,7 +72,6 @@ class ExerciseMapperImplTest {
         .description("Exercise that focuses on the quadriceps")
         .additional("Apply the Rest in Pause technique in the last set")
         .sets(4)
-        .weight(50.0)
         .createdAt(LocalDateTime.parse("2025-05-12T10:00:00"))
         .workout(Workout.builder().id(1_000L).build())
         .build();
@@ -87,7 +83,6 @@ class ExerciseMapperImplTest {
         .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
         .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
         .hasFieldOrPropertyWithValue("sets", 4)
-        .hasFieldOrPropertyWithValue("weight", 50.0)
         .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:00:00"))
         .hasFieldOrPropertyWithValue("updatedAt", null);
   }

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/WeightMapperImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/WeightMapperImplTest.java
@@ -1,0 +1,89 @@
+package br.com.emendes.workout_tracker_api.unit.mapper.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.mapper.impl.WeightMapperImpl;
+import br.com.emendes.workout_tracker_api.model.UnitOfMeasurement;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Unit tests for WeightMapperImpl")
+class WeightMapperImplTest {
+
+  private final WeightMapperImpl weightMapper = new WeightMapperImpl();
+
+  @Test
+  @DisplayName("toWeight must return Weight when map successfully")
+  void toWeight_MustReturnWeight_WhenMapSuccessfully() {
+    WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+        .value("60.0")
+        .unit("KILOGRAMS")
+        .build();
+    Weight actualWeight = weightMapper.toWeight(1_000_000L, weightCreateRequest);
+
+    assertThat(actualWeight).isNotNull()
+        .hasFieldOrPropertyWithValue("value", new BigDecimal("60.0"))
+        .hasFieldOrPropertyWithValue("unit", UnitOfMeasurement.KILOGRAMS);
+    assertThat(actualWeight.getId()).isNull();
+    assertThat(actualWeight.getCreatedAt()).isNotNull();
+    assertThat(actualWeight.getExercise()).isNotNull()
+        .hasFieldOrPropertyWithValue("id", 1_000_000L);
+  }
+
+  @Test
+  @DisplayName("toWeight must throw IllegalArgumentException when weightCreateRequest is null")
+  void toWeight_MustThrowIllegalArgumentException_WhenWeightCreateRequestIsNull() {
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> weightMapper.toWeight(1_000_000L, null))
+        .withMessage("weightCreateRequest must not be null");
+  }
+
+  @Test
+  @DisplayName("toWeight must throw IllegalArgumentException when exerciseId is null")
+  void toWeight_MustThrowIllegalArgumentException_WhenExerciseIdIsNull() {
+    WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+        .value("60.0")
+        .unit("KILOGRAM")
+        .build();
+
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> weightMapper.toWeight(null, weightCreateRequest))
+        .withMessage("exerciseId must not be null");
+  }
+
+  @Test
+  @DisplayName("toWeightResponse must return Weight when map successfully")
+  void toWeightResponse_MustReturnWeight_WhenMapSuccessfully() {
+    Weight weight = Weight.builder()
+        .id(1_000_000_000L)
+        .value(new BigDecimal("60.0"))
+        .unit(UnitOfMeasurement.KILOGRAMS)
+        .createdAt(LocalDateTime.parse("2025-05-12T12:00:00"))
+        .exercise(Exercise.builder().id(1_000_000L).build())
+        .build();
+    WeightResponse actualWeightResponse = weightMapper.toWeightResponse(weight);
+
+    assertThat(actualWeightResponse).isNotNull()
+        .hasFieldOrPropertyWithValue("id", 1_000_000_000L)
+        .hasFieldOrPropertyWithValue("value", "60.0")
+        .hasFieldOrPropertyWithValue("unit", "KILOGRAMS")
+        .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T12:00:00"));
+  }
+
+  @Test
+  @DisplayName("toWeightResponse must throw IllegalArgumentException when weight is null")
+  void toWeightResponse_MustThrowIllegalArgumentException_WhenWeightIsNull() {
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> weightMapper.toWeightResponse(null))
+        .withMessage("weight must not be null");
+  }
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/ExerciseServiceImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/ExerciseServiceImplTest.java
@@ -1,9 +1,13 @@
 package br.com.emendes.workout_tracker_api.unit.service.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.exception.ExerciseNotFoundException;
 import br.com.emendes.workout_tracker_api.mapper.ExerciseMapper;
 import br.com.emendes.workout_tracker_api.repository.ExerciseRepository;
+import br.com.emendes.workout_tracker_api.service.WeightService;
 import br.com.emendes.workout_tracker_api.service.impl.ExerciseServiceImpl;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,10 +19,14 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.*;
+import static br.com.emendes.workout_tracker_api.util.faker.WeightFaker.weightResponse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -31,6 +39,8 @@ class ExerciseServiceImplTest {
   private ExerciseMapper exerciseMapperMock;
   @Mock
   private ExerciseRepository exerciseRepositoryMock;
+  @Mock
+  private WeightService weightServiceMock;
 
   @Nested
   @DisplayName("Create Method")
@@ -48,7 +58,6 @@ class ExerciseServiceImplTest {
           .description("Exercise that focuses on the quadriceps")
           .additional("Apply the Rest in Pause technique in the last set")
           .sets(4)
-          .weight(50.0)
           .build();
 
       ExerciseResponse actualExerciseResponse = exerciseService.create(1_000L, exerciseCreateRequest);
@@ -58,10 +67,54 @@ class ExerciseServiceImplTest {
           .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
           .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
           .hasFieldOrPropertyWithValue("sets", 4)
-          .hasFieldOrPropertyWithValue("weight", 50.0)
           .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:30:00"));
       assertThat(actualExerciseResponse.id()).isNotNull();
       assertThat(actualExerciseResponse.updatedAt()).isNull();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("AddWeight Method")
+  class AddWeightMethod {
+
+    @Test
+    @DisplayName("addWeight must return WeightResponse when add successfully")
+    void addWeight_MustReturnWeightResponse_WhenAddSuccessfully() {
+      when(exerciseRepositoryMock.findById(any())).thenReturn(exerciseOptional());
+      when(weightServiceMock.create(any(), any())).thenReturn(weightResponse());
+
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value("60.0")
+          .unit("KILOGRAMS")
+          .build();
+
+      WeightResponse actualWeightResponse = exerciseService.addWeight(1_000L, weightCreateRequest);
+
+      verify(exerciseRepositoryMock).findById(any());
+      verify(weightServiceMock).create(any(), any());
+      verify(exerciseRepositoryMock).save(any());
+
+      assertThat(actualWeightResponse).isNotNull()
+          .hasFieldOrPropertyWithValue("value", "60.0")
+          .hasFieldOrPropertyWithValue("unit", "KILOGRAMS")
+          .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T11:00:00"));
+      assertThat(actualWeightResponse.id()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("addWeight must throw ExerciseNotFoundException when not exists Exercise for given id")
+    void addWeight_MusThrowExerciseNotFoundException_WhenNotExistsExerciseForGivenID() {
+      when(exerciseRepositoryMock.findById(any())).thenReturn(Optional.empty());
+
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value("60.0")
+          .unit("KILOGRAMS")
+          .build();
+
+      assertThatExceptionOfType(ExerciseNotFoundException.class)
+          .isThrownBy(() -> exerciseService.addWeight(9_999_999L, weightCreateRequest))
+          .withMessage("exercise not found with id: 9999999");
     }
 
   }

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/WeightServiceImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/WeightServiceImplTest.java
@@ -1,0 +1,62 @@
+package br.com.emendes.workout_tracker_api.unit.service.impl;
+
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.mapper.WeightMapper;
+import br.com.emendes.workout_tracker_api.repository.WeightRepository;
+import br.com.emendes.workout_tracker_api.service.impl.WeightServiceImpl;
+import br.com.emendes.workout_tracker_api.util.faker.WeightFaker;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@DisplayName("Unit tests for WeightServiceImpl")
+class WeightServiceImplTest {
+
+  @InjectMocks
+  private WeightServiceImpl weightService;
+  @Mock
+  private WeightMapper weightMapperMock;
+  @Mock
+  private WeightRepository weightRepositoryMock;
+
+  @Nested
+  @DisplayName("Create Method")
+  class CreateMethod {
+
+    @Test
+    @DisplayName("create must return WeightResponse when create successfully")
+    void create_MustReturnWeightResponse_WhenCreateSuccessfully() {
+      when(weightMapperMock.toWeight(any(), any())).thenReturn(WeightFaker.nonCreatedWeight());
+      when(weightRepositoryMock.save(any())).thenReturn(WeightFaker.weight());
+      when(weightMapperMock.toWeightResponse(any())).thenReturn(WeightFaker.weightResponse());
+
+      WeightCreateRequest weightCreateRequest = WeightCreateRequest.builder()
+          .value("60.0")
+          .unit("KILOGRAMS")
+          .build();
+
+      WeightResponse actualWeightResponse = weightService.create(1_000_000L, weightCreateRequest);
+
+      Assertions.assertThat(actualWeightResponse).isNotNull()
+          .hasFieldOrPropertyWithValue("value", "60.0")
+          .hasFieldOrPropertyWithValue("unit", "KILOGRAMS")
+          .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T11:00:00"));
+      assertThat(actualWeightResponse.id()).isNotNull();
+    }
+
+  }
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/WorkoutServiceImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/WorkoutServiceImplTest.java
@@ -1,8 +1,10 @@
 package br.com.emendes.workout_tracker_api.unit.service.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.exception.WorkoutNotFoundException;
 import br.com.emendes.workout_tracker_api.mapper.WorkoutMapper;
@@ -21,6 +23,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.time.LocalDateTime;
 
 import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.exerciseResponse;
+import static br.com.emendes.workout_tracker_api.util.faker.WeightFaker.weightResponse;
 import static br.com.emendes.workout_tracker_api.util.faker.WorkoutFaker.nonCreatedWorkout;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -83,7 +86,6 @@ class WorkoutServiceImplTest {
           .description("Exercise that focuses on the quadriceps")
           .additional("Apply the Rest in Pause technique in the last set")
           .sets(4)
-          .weight(50.0)
           .build();
 
       ExerciseResponse actualExerciseResponse = workoutService.addExercise(1_000L, exerciseCreateRequest);
@@ -93,14 +95,13 @@ class WorkoutServiceImplTest {
           .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
           .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
           .hasFieldOrPropertyWithValue("sets", 4)
-          .hasFieldOrPropertyWithValue("weight", 50.0)
           .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:30:00"));
       assertThat(actualExerciseResponse.id()).isNotNull();
       assertThat(actualExerciseResponse.updatedAt()).isNull();
     }
 
     @Test
-    @DisplayName("addExercise must throw WorkoutNotFoundExceptio when not exists Workout for given id")
+    @DisplayName("addExercise must throw WorkoutNotFoundException when not exists Workout for given id")
     void addExercise_MusThrowWorkoutNotFoundException_WhenNotExistsWorkoutForGivenID() {
       when(workoutRepositoryMock.existsById(any())).thenReturn(false);
 
@@ -109,11 +110,52 @@ class WorkoutServiceImplTest {
           .description("Exercise that focuses on the quadriceps")
           .additional("Apply the Rest in Pause technique in the last set")
           .sets(4)
-          .weight(50.0)
           .build();
 
       assertThatExceptionOfType(WorkoutNotFoundException.class)
           .isThrownBy(() -> workoutService.addExercise(9_999L, exerciseCreateRequest))
+          .withMessage("workout not found with id: 9999");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("AddWeight Method")
+  class AddWeightMethod {
+
+    @Test
+    @DisplayName("addWeight must return WeightResponse when add successfully")
+    void addWeight_MustReturnWeightResponse_WhenAddSuccessfully() {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(true);
+      when(exerciseServiceMock.addWeight(any(), any())).thenReturn(weightResponse());
+
+      WeightCreateRequest exerciseCreateRequest = WeightCreateRequest.builder()
+          .value("60.0")
+          .unit("KILOGRAMS")
+          .build();
+
+      WeightResponse actualWeightResponse = workoutService
+          .addWeight(1_000L, 1_000_000L, exerciseCreateRequest);
+
+      assertThat(actualWeightResponse).isNotNull()
+          .hasFieldOrPropertyWithValue("value", "60.0")
+          .hasFieldOrPropertyWithValue("unit", "KILOGRAMS")
+          .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T11:00:00"));
+      assertThat(actualWeightResponse.id()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("addWeight must throw WorkoutNotFoundException when not exists Workout for given id")
+    void addWeight_MusThrowWorkoutNotFoundException_WhenNotExistsWorkoutForGivenID() {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(false);
+
+      WeightCreateRequest exerciseCreateRequest = WeightCreateRequest.builder()
+          .value("60.0")
+          .unit("KILOGRAMS")
+          .build();
+
+      assertThatExceptionOfType(WorkoutNotFoundException.class)
+          .isThrownBy(() -> workoutService.addWeight(9_999L, 1_000_000L, exerciseCreateRequest))
           .withMessage("workout not found with id: 9999");
     }
 

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/faker/ExerciseFaker.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/faker/ExerciseFaker.java
@@ -4,6 +4,7 @@ import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static br.com.emendes.workout_tracker_api.util.faker.WorkoutFaker.workout;
 
@@ -17,7 +18,6 @@ public class ExerciseFaker {
   public static final String EXERCISE_DESCRIPTION = "Exercise that focuses on the quadriceps";
   public static final String EXERCISE_ADDITIONAL = "Apply the Rest in Pause technique in the last set";
   public static final int EXERCISE_SETS = 4;
-  public static final double EXERCISE_WEIGHT = 50.0;
   public static final LocalDateTime EXERCISE_CREATED_AT = LocalDateTime.parse("2025-05-12T10:30:00");
 
   private ExerciseFaker() {
@@ -33,14 +33,13 @@ public class ExerciseFaker {
         .description(EXERCISE_DESCRIPTION)
         .additional(EXERCISE_ADDITIONAL)
         .sets(EXERCISE_SETS)
-        .weight(EXERCISE_WEIGHT)
         .createdAt(EXERCISE_CREATED_AT)
         .build();
   }
 
   /**
    * Cria um objeto Exercise sem id e updatedAt e com os campos name, description,
-   * additional, sets, weight, workout e createdAt.
+   * additional, sets, workout e createdAt.
    */
   public static Exercise nonCreatedExercise() {
     return Exercise.builder()
@@ -48,7 +47,6 @@ public class ExerciseFaker {
         .description(EXERCISE_DESCRIPTION)
         .additional(EXERCISE_ADDITIONAL)
         .sets(EXERCISE_SETS)
-        .weight(EXERCISE_WEIGHT)
         .createdAt(EXERCISE_CREATED_AT)
         .workout(workout())
         .build();
@@ -64,9 +62,16 @@ public class ExerciseFaker {
         .description(EXERCISE_DESCRIPTION)
         .additional(EXERCISE_ADDITIONAL)
         .sets(EXERCISE_SETS)
-        .weight(EXERCISE_WEIGHT)
         .createdAt(EXERCISE_CREATED_AT)
         .workout(workout())
         .build();
   }
+
+  /**
+   * Cria um objeto {@code Optional<Exercise>} contendo um objeto Exercise.
+   */
+  public static Optional<Exercise> exerciseOptional() {
+    return Optional.of(exercise());
+  }
+
 }

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/faker/WeightFaker.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/faker/WeightFaker.java
@@ -1,0 +1,61 @@
+package br.com.emendes.workout_tracker_api.util.faker;
+
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+import br.com.emendes.workout_tracker_api.model.UnitOfMeasurement;
+import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Classe utilitária que gera objetos relacionados a Workout para uso em testes automatizados.
+ */
+public class WeightFaker {
+
+  private static final Long WEIGHT_ID = 1_000_000_000L;
+  private static final BigDecimal WEIGHT_VALUE = new BigDecimal("60.0");
+  private static final UnitOfMeasurement WEIGHT_UNIT = UnitOfMeasurement.KILOGRAMS;
+  private static final LocalDateTime WEIGHT_CREATED_AT = LocalDateTime.parse("2025-05-12T11:00:00");
+  private static final Exercise WEIGHT_EXERCISE = Exercise.builder().id(ExerciseFaker.EXERCISE_ID).build();
+
+  private WeightFaker() {
+  }
+
+  /**
+   * Cria um objeto Weight sem id e com os campos value, unit, exercise e createdAt.
+   */
+  public static Weight nonCreatedWeight() {
+    return Weight.builder()
+        .value(WEIGHT_VALUE)
+        .unit(WEIGHT_UNIT)
+        .createdAt(WEIGHT_CREATED_AT)
+        .exercise(WEIGHT_EXERCISE)
+        .build();
+  }
+
+  /**
+   * Cria um objeto Weight com todos os campos.
+   */
+  public static Weight weight() {
+    return Weight.builder()
+        .id(WEIGHT_ID)
+        .value(WEIGHT_VALUE)
+        .unit(WEIGHT_UNIT)
+        .createdAt(WEIGHT_CREATED_AT)
+        .exercise(WEIGHT_EXERCISE)
+        .build();
+  }
+
+  /**
+   * Cria um objeto WeightResponse com todos os campos.
+   */
+  public static WeightResponse weightResponse() {
+    return WeightResponse.builder()
+        .id(WEIGHT_ID)
+        .value(WEIGHT_VALUE.toString())
+        .unit(WEIGHT_UNIT.toString())
+        .createdAt(WEIGHT_CREATED_AT)
+        .build();
+  }
+}


### PR DESCRIPTION
Adiciona um endpoint POST /api/v1/workouts/{workoutId}/exercises/{exerciseId}/weights para adicionar uma carga (weight) a um exercício (exercise).

- add WeightResponse
- add WeightMapper
- add migration para a tabela tb_weight
- add migration para adicionar coluna weight_id em tb_exercise
- add WeightService
- add WeightServiceImpl unit tests
- add ExerciseService.addWeight
- add WorkoutService.addWeight
- add endpoint POST /api/v1/workouts/{workoutId}/exercises/{exerciseId}/weights