### PR TITLE
feat: add endpoint GET /api/v1/workouts para busca de Workout por status

### DIFF
--- a/src/main/java/br/com/emendes/workout_tracker_api/WorkoutTrackerApiApplication.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/WorkoutTrackerApiApplication.java
@@ -2,12 +2,14 @@ package br.com.emendes.workout_tracker_api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 @SpringBootApplication
 public class WorkoutTrackerApiApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(WorkoutTrackerApiApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(WorkoutTrackerApiApplication.class, args);
+  }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
@@ -8,6 +8,9 @@ import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.service.WorkoutService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -78,6 +81,26 @@ public class WorkoutController {
         .build(workoutId, exerciseId, weightResponse.id());
 
     return ResponseEntity.created(location).body(weightResponse);
+  }
+
+  /**
+   * Método responsável pelo endpoint GET /api/v1/workouts para buscar o recurso Workout,
+   * é opcional a busca por status.
+   * <br><br>
+   * Caso o parâmetro status seja informado, buscará os Workouts com tal status,
+   * e caso não seja informado, buscará todos os Workouts.
+   * <br><br>
+   * A busca é paginada.
+   *
+   * @param status   WorkoutStatus que os Workouts devem ter, pode ser null.
+   * @param pageable modo como será feito a paginação.
+   * @return {@code Page<WorkoutResponse>} objeto Page contendo os Workouts encontrados.
+   */
+  @GetMapping
+  ResponseEntity<Page<WorkoutResponse>> fetch(
+      @RequestParam(name = "status", required = false) String status,
+      @PageableDefault Pageable pageable) {
+    return ResponseEntity.ok(workoutService.fetch(status, pageable));
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/response/WorkoutResponse.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/response/WorkoutResponse.java
@@ -7,18 +7,18 @@ import java.time.LocalDateTime;
 /**
  * Record DTO com os dados de Workout.
  *
- * @param id                  identificador do workout.
- * @param name                nome do workout.
- * @param description         descrição do workout.
- * @param isInUse indica se o workout está em uso, true caso esteja, false caso contrário.
- * @param createdAt           data em que foi criado o workout.
+ * @param id          identificador do workout.
+ * @param name        nome do workout.
+ * @param description descrição do workout.
+ * @param status      indica o status do Workout.
+ * @param createdAt   data em que foi criado o workout.
  */
 @Builder
 public record WorkoutResponse(
     Long id,
     String name,
     String description,
-    boolean isInUse,
+    String status,
     LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/WorkoutMapperImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/WorkoutMapperImpl.java
@@ -3,6 +3,7 @@ package br.com.emendes.workout_tracker_api.mapper.impl;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.mapper.WorkoutMapper;
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -22,7 +23,7 @@ public class WorkoutMapperImpl implements WorkoutMapper {
     return Workout.builder()
         .name(workoutCreateRequest.name())
         .description(workoutCreateRequest.description())
-        .isInUse(true)
+        .status(WorkoutStatus.ONGOING)
         .createdAt(LocalDateTime.now())
         .build();
   }
@@ -35,7 +36,7 @@ public class WorkoutMapperImpl implements WorkoutMapper {
         .id(workout.getId())
         .name(workout.getName())
         .description(workout.getDescription())
-        .isInUse(workout.isInUse())
+        .status(workout.getStatus().toString())
         .createdAt(workout.getCreatedAt())
         .build();
   }

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/UnitOfMeasurement.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/UnitOfMeasurement.java
@@ -1,11 +1,25 @@
 package br.com.emendes.workout_tracker_api.model;
 
 /**
- * Enum para indicar as unidades de medida das cargas.
+ * Enum para indicar as unidades de medida das cargas, abaixo estão as mais comuns para tempo e massa.
  */
 public enum UnitOfMeasurement {
+
+  /**
+   * Unidade de massa quilograma.
+   */
   KILOGRAMS,
+  /**
+   * Unidade de massa libras.
+   */
   POUNDS,
+  /**
+   * Unidade de tempo minutos.
+   */
   MINUTES,
+  /**
+   * Unidade de tempo horas.
+   */
   HOURS
+
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/WorkoutStatus.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/WorkoutStatus.java
@@ -1,0 +1,17 @@
+package br.com.emendes.workout_tracker_api.model;
+
+/**
+ * Enum para indicar o status dos Workouts.
+ */
+public enum WorkoutStatus {
+
+  /**
+   * Significa que o Workout está em uso atualmente, que faz parte da rotina de treino do usuário.
+   */
+  ONGOING,
+  /**
+   * Significa que o Workout NÃO está mais em uso, que já não faz mais parte da rotina de treino do usuário.
+   */
+  FINISHED
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Workout.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Workout.java
@@ -1,5 +1,6 @@
 package br.com.emendes.workout_tracker_api.model.entity;
 
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -27,8 +28,9 @@ public class Workout {
   private String name;
   @Column(name = "description")
   private String description;
-  @Column(name = "is_in_use", nullable = false)
-  private boolean isInUse;
+  @Column(name = "status", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private WorkoutStatus status;
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 

--- a/src/main/java/br/com/emendes/workout_tracker_api/repository/WorkoutRepository.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/repository/WorkoutRepository.java
@@ -1,12 +1,23 @@
 package br.com.emendes.workout_tracker_api.repository;
 
-
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Interface repository com as abstrações para interação com o recurso Workout no banco de dados.
  */
 public interface WorkoutRepository extends JpaRepository<Workout, Long> {
+
+  /**
+   * Busca paginada de Workout por status.
+   *
+   * @param status   WorkoutStatus que o Workout deve ter.
+   * @param pageable modo como deve ser feito a paginação.
+   * @return {@code Page<Workout>} objetos Workouts encontrados e paginados.
+   */
+  Page<Workout> findByStatus(WorkoutStatus status, Pageable pageable);
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
@@ -6,8 +6,11 @@ import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
+import br.com.emendes.workout_tracker_api.validation.annotation.ValidWorkoutStatus;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 
 /**
@@ -48,4 +51,17 @@ public interface WorkoutService {
       Long exerciseId,
       WeightCreateRequest weightCreateRequest);
 
+  /**
+   * Busca paginada de de Workouts, opcional busca por status.
+   * <br><br>
+   * Se o {@code status} for informado, somente os workouts com tal status serão retornados,
+   * caso {@code status} for null, todos os workouts (dentro do limite da paginação) serão retornados.
+   *
+   * @param status   status dos workouts a ser buscado (pode ser null).
+   * @param pageable modo como será feita a paginação dos dados.
+   * @return {@code Page<WorkoutResponse>} Página com os Workout encontrados.
+   */
+  Page<WorkoutResponse> fetch(
+      @ValidWorkoutStatus(message = "status must be a valid workout status (i.e. ONGOING, FINISHED)") String status,
+      @NotNull(message = "pageable must not be null") Pageable pageable);
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
@@ -8,12 +8,15 @@ import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.exception.WorkoutNotFoundException;
 import br.com.emendes.workout_tracker_api.mapper.WorkoutMapper;
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
 import br.com.emendes.workout_tracker_api.repository.WorkoutRepository;
 import br.com.emendes.workout_tracker_api.service.ExerciseService;
 import br.com.emendes.workout_tracker_api.service.WorkoutService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -54,7 +57,16 @@ public class WorkoutServiceImpl implements WorkoutService {
     verifyIfExistsWorkout(workoutId);
 
     return exerciseService.addWeight(exerciseId, weightCreateRequest);
+  }
 
+  @Override
+  public Page<WorkoutResponse> fetch(String status, Pageable pageable) {
+    log.info("attempt to fetch Workouts with page: {} and size: {}", pageable.getPageNumber(), pageable.getPageNumber());
+    Page<Workout> workoutPage = status == null ? workoutRepository.findAll(pageable) :
+        workoutRepository.findByStatus(WorkoutStatus.valueOf(status.toUpperCase()), pageable);
+
+    log.info("workouts fetched successfully");
+    return workoutPage.map(workoutMapper::toWorkoutResponse);
   }
 
   /**

--- a/src/main/java/br/com/emendes/workout_tracker_api/validation/annotation/ValidWorkoutStatus.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/validation/annotation/ValidWorkoutStatus.java
@@ -1,0 +1,32 @@
+package br.com.emendes.workout_tracker_api.validation.annotation;
+
+import br.com.emendes.workout_tracker_api.validation.validator.WorkoutStatusValidator;
+import jakarta.validation.Constraint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Verifica se o elemento anotado é um WorkoutStatus.<br>
+ * <br>
+ * WorkoutStatus válidos: ONGOING, FINISHED.<br>
+ * Letras minúsculas também são aceitas (i.e. Ongoing, OnGoInG são valores válidos)
+ * <br><br>
+ * Suporta tipo String.
+ * <br><br>
+ * Elementos {@code null} são considerados válidos.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = WorkoutStatusValidator.class)
+public @interface ValidWorkoutStatus {
+
+  String message() default "must be a valid WorkoutStatus";
+
+  Class<?>[] groups() default {};
+
+  Class<?>[] payload() default {};
+
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/validation/validator/WorkoutStatusValidator.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/validation/validator/WorkoutStatusValidator.java
@@ -1,0 +1,24 @@
+package br.com.emendes.workout_tracker_api.validation.validator;
+
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
+import br.com.emendes.workout_tracker_api.validation.annotation.ValidWorkoutStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validador de {@link ValidWorkoutStatus}.
+ */
+public class WorkoutStatusValidator implements ConstraintValidator<ValidWorkoutStatus, String> {
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) return true;
+    try {
+      WorkoutStatus.valueOf(value.toUpperCase());
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+}

--- a/src/main/resources/db/migration/V01__CREATE_TABLE_WORKOUT.sql
+++ b/src/main/resources/db/migration/V01__CREATE_TABLE_WORKOUT.sql
@@ -2,7 +2,7 @@ CREATE TABLE tb_workout (
     id bigserial NOT NULL,
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255) NULL,
-    is_in_use boolean NOT NULL,
+    status VARCHAR(50) NOT NULL,
     created_at timestamp NOT NULL,
     CONSTRAINT tb_workout__f_id__pk PRIMARY KEY (id)
 );

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/WorkoutMapperImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/WorkoutMapperImplTest.java
@@ -3,6 +3,7 @@ package br.com.emendes.workout_tracker_api.unit.mapper.impl;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
 import br.com.emendes.workout_tracker_api.mapper.impl.WorkoutMapperImpl;
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +30,7 @@ class WorkoutMapperImplTest {
     assertThat(actualWorkout).isNotNull()
         .hasFieldOrPropertyWithValue("name", "Leg day")
         .hasFieldOrPropertyWithValue("description", "Lower body focused workout")
-        .hasFieldOrPropertyWithValue("isInUse", true);
+        .hasFieldOrPropertyWithValue("status", WorkoutStatus.ONGOING);
     assertThat(actualWorkout.getId()).isNull();
     assertThat(actualWorkout.getCreatedAt()).isNotNull();
   }
@@ -49,7 +50,7 @@ class WorkoutMapperImplTest {
         .id(1_000L)
         .name("Leg day")
         .description("Lower body focused workout")
-        .isInUse(true)
+        .status(WorkoutStatus.ONGOING)
         .createdAt(LocalDateTime.parse("2025-05-12T10:00:00"))
         .build();
     WorkoutResponse actualWorkoutResponse = workoutMapper.toWorkoutResponse(workout);
@@ -58,7 +59,7 @@ class WorkoutMapperImplTest {
         .hasFieldOrPropertyWithValue("id", 1_000L)
         .hasFieldOrPropertyWithValue("name", "Leg day")
         .hasFieldOrPropertyWithValue("description", "Lower body focused workout")
-        .hasFieldOrPropertyWithValue("isInUse", true)
+        .hasFieldOrPropertyWithValue("status", "ONGOING")
         .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:00:00"));
   }
 

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/faker/WorkoutFaker.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/faker/WorkoutFaker.java
@@ -1,9 +1,15 @@
 package br.com.emendes.workout_tracker_api.util.faker;
 
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
+import br.com.emendes.workout_tracker_api.model.WorkoutStatus;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * Classe utilitária que gera objetos relacionados a Workout para uso em testes automatizados.
@@ -14,6 +20,7 @@ public class WorkoutFaker {
   public static final String WORKOUT_NAME = "Leg day";
   public static final String WORKOUT_DESCRIPTION = "Lower body focused workout";
   public static final LocalDateTime WORKOUT_CREATED_AT = LocalDateTime.parse("2025-05-12T10:00:00");
+  public static final Pageable WORKOUT_PAGEABLE = PageRequest.of(0, 10);
 
   private WorkoutFaker() {
   }
@@ -25,7 +32,7 @@ public class WorkoutFaker {
     return Workout.builder()
         .name(WORKOUT_NAME)
         .description(WORKOUT_DESCRIPTION)
-        .isInUse(true)
+        .status(WorkoutStatus.ONGOING)
         .createdAt(WORKOUT_CREATED_AT)
         .build();
   }
@@ -38,7 +45,7 @@ public class WorkoutFaker {
         .id(WORKOUT_ID)
         .name(WORKOUT_NAME)
         .description(WORKOUT_DESCRIPTION)
-        .isInUse(true)
+        .status(WorkoutStatus.ONGOING)
         .createdAt(WORKOUT_CREATED_AT)
         .build();
   }
@@ -51,8 +58,16 @@ public class WorkoutFaker {
         .id(WORKOUT_ID)
         .name(WORKOUT_NAME)
         .description(WORKOUT_DESCRIPTION)
-        .isInUse(true)
+        .status(WorkoutStatus.ONGOING.toString())
         .createdAt(WORKOUT_CREATED_AT)
         .build();
   }
+
+  /**
+   * Cria um objeto {@code Page<Workout>}.
+   */
+  public static Page<Workout> workoutPage() {
+    return new PageImpl<>(List.of(workout()), WORKOUT_PAGEABLE, 1);
+  }
+
 }

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/wrapper/PageResponse.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/wrapper/PageResponse.java
@@ -1,0 +1,27 @@
+package br.com.emendes.workout_tracker_api.util.wrapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Record para mapear response body que são paginados.
+ *
+ * @param content representa o conjunto dos objetos encontrados.
+ * @param page    modo como foi feita a paginação.
+ * @param <T>     tipo de objeto do encontrado.
+ */
+public record PageResponse<T>(List<T> content, PageInfo page) {
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public PageResponse(
+      @JsonProperty("content") List<T> content, @JsonProperty("page") PageInfo page) {
+    this.content = content;
+    this.page = page;
+  }
+
+  public record PageInfo(int size, int number, int totalElements, int totalPages) {
+  }
+
+}


### PR DESCRIPTION
Adiciona endpoint /api/v1/workouts para busca paginada de Workouts por status.

- add WorkoutService.fetch
- add implementação de WorkoutService.fetch
- add EnableSpringDataWebSupport para definir o modo de serialização de Page
- add integration tests para o endpoint GET /api/v1/workouts
- add WorkoutServiceImpl.fetch unit tests
- add javadocs dos métodos criados