### PR TITLE
feat: add endpoint GET /api/v1/workouts/{wId}/exercises para buscar exercises de um workout

### DIFF
--- a/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/controller/WorkoutController.java
@@ -3,6 +3,7 @@ package br.com.emendes.workout_tracker_api.controller;
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
@@ -34,7 +35,7 @@ public class WorkoutController {
    * @param uriBuilder           objeto que mantém o host do endpoint para construção do header location.
    */
   @PostMapping
-  ResponseEntity<WorkoutResponse> create(
+  ResponseEntity<WorkoutResponse> createWorkout(
       @RequestBody WorkoutCreateRequest workoutCreateRequest, UriComponentsBuilder uriBuilder) {
     WorkoutResponse workoutResponse = workoutService.create(workoutCreateRequest);
     URI location = uriBuilder.path("/api/v1/workout/{id}").build(workoutResponse.id());
@@ -66,9 +67,9 @@ public class WorkoutController {
    * Método responsável pelo endpoint POST /api/v1/workouts/{workoutId}/exercises/{exerciseId}/weights
    * para adicionar o recurso Weight ao Exercise.
    *
-   * @param workoutId             identificador do Workout que receberá o Exercise.
-   * @param exerciseCreateRequest objeto contendo as informações do Exercise que será adicionado.
-   * @param uriBuilder            objeto que mantém o host do endpoint para construção do header location.
+   * @param workoutId           identificador do Workout que receberá o Exercise.
+   * @param weightCreateRequest objeto contendo as informações do Weight que será adicionado.
+   * @param uriBuilder          objeto que mantém o host do endpoint para construção do header location.
    */
   @PostMapping("/{workoutId}/exercises/{exerciseId}/weights")
   ResponseEntity<WeightResponse> addWeight(
@@ -97,10 +98,25 @@ public class WorkoutController {
    * @return {@code Page<WorkoutResponse>} objeto Page contendo os Workouts encontrados.
    */
   @GetMapping
-  ResponseEntity<Page<WorkoutResponse>> fetch(
+  ResponseEntity<Page<WorkoutResponse>> fetchWorkouts(
       @RequestParam(name = "status", required = false) String status,
       @PageableDefault Pageable pageable) {
     return ResponseEntity.ok(workoutService.fetch(status, pageable));
+  }
+
+  /**
+   * Método responsável pelo endpoint GET /api/v1/workouts/{workoutId}/exercises para buscar o recurso Exercise
+   * de um dado Workout.
+   *
+   * @param workoutId identificador do Workout relacionado com os exercises buscados.
+   * @param pageable  modo como será feito a paginação.
+   * @return {@code Page<ExerciseDetailsResponse>} objeto Page contendo os Exercises encontrados.
+   */
+  @GetMapping("/{workoutId}/exercises")
+  ResponseEntity<Page<ExerciseDetailsResponse>> fetchExercises(
+      @PathVariable("workoutId") Long workoutId,
+      @PageableDefault Pageable pageable) {
+    return ResponseEntity.ok(workoutService.fetchExercises(workoutId, pageable));
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/dto/response/ExerciseDetailsResponse.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/dto/response/ExerciseDetailsResponse.java
@@ -1,0 +1,18 @@
+package br.com.emendes.workout_tracker_api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Builder;
+
+/**
+ * Record DTO com as informações detalhadas de Exercise.
+ *
+ * @param exercise contém as informações do Exercise.
+ * @param weight   contém as informações da carga do Exercise.
+ */
+@Builder
+public record ExerciseDetailsResponse(
+    @JsonUnwrapped
+    ExerciseResponse exercise,
+    WeightResponse weight
+) {
+}

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/ExerciseMapper.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/ExerciseMapper.java
@@ -1,6 +1,7 @@
 package br.com.emendes.workout_tracker_api.mapper;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
 
@@ -28,5 +29,13 @@ public interface ExerciseMapper {
    * @return ExerciseResponse com as informações de Exercise.
    */
   ExerciseResponse toExerciseResponse(Exercise exercise);
+
+  /**
+   * Mapeia um objeto {@link Exercise} para {@link ExerciseDetailsResponse}.
+   *
+   * @param exercise objeto que será mapeado.
+   * @return {@code ExerciseDetailsResponse} objeto com os dados de Exercise.
+   */
+  ExerciseDetailsResponse toExerciseDetailsResponse(Exercise exercise);
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/ExerciseMapperImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/mapper/impl/ExerciseMapperImpl.java
@@ -1,10 +1,13 @@
 package br.com.emendes.workout_tracker_api.mapper.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.mapper.ExerciseMapper;
+import br.com.emendes.workout_tracker_api.mapper.WeightMapper;
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
@@ -14,7 +17,10 @@ import java.time.LocalDateTime;
  * Implementação de {@link ExerciseMapper}.
  */
 @Component
+@RequiredArgsConstructor
 public class ExerciseMapperImpl implements ExerciseMapper {
+
+  private final WeightMapper weightMapper;
 
   @Override
   public Exercise toExercise(Long workoutId, ExerciseCreateRequest exerciseCreateRequest) {
@@ -44,6 +50,17 @@ public class ExerciseMapperImpl implements ExerciseMapper {
         .createdAt(exercise.getCreatedAt())
         .updatedAt(exercise.getUpdatedAt())
         .build();
+  }
+
+  @Override
+  public ExerciseDetailsResponse toExerciseDetailsResponse(Exercise exercise) {
+    Assert.notNull(exercise, "exercise must not be null");
+
+    ExerciseDetailsResponse.ExerciseDetailsResponseBuilder builder = ExerciseDetailsResponse.builder()
+        .exercise(toExerciseResponse(exercise));
+    if (exercise.getWeight() != null) builder.weight(weightMapper.toWeightResponse(exercise.getWeight()));
+
+    return builder.build();
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Exercise.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/model/entity/Exercise.java
@@ -37,7 +37,7 @@ public class Exercise {
   private LocalDateTime updatedAt;
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   private Workout workout;
-  @OneToOne(fetch = FetchType.LAZY)
+  @OneToOne
   private Weight weight;
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/repository/ExerciseRepository.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/repository/ExerciseRepository.java
@@ -1,10 +1,22 @@
 package br.com.emendes.workout_tracker_api.repository;
 
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Interface repository com as abstrações para interação com o recurso Exercise no banco de dados.
  */
 public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+
+  /**
+   * Busca paginada de Exercise por workoutId.
+   *
+   * @param workoutId identificador do Workout relacionado com o exercise.
+   * @param pageable  modo como deve ser feita a paginação dos dados.
+   * @return {@code Page<Exercise>} Page com os Exercises encontrados.
+   */
+  Page<Exercise> findByWorkoutId(Long workoutId, Pageable pageable);
+
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/ExerciseService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/ExerciseService.java
@@ -2,9 +2,12 @@ package br.com.emendes.workout_tracker_api.service;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * Interface com as abstrações para manipulação do recurso Exercise.
@@ -30,5 +33,14 @@ public interface ExerciseService {
   WeightResponse addWeight(
       @NotNull(message = "exerciseId must not be null") Long exerciseId,
       WeightCreateRequest weightCreateRequest);
+
+  /**
+   * Busca paginada de Exercises por workoutId.
+   *
+   * @param workoutId identificador do Workout ao qual os exercises devem estar relacionados.
+   * @param pageable  modo como deve ser feita a paginação dos dados.
+   * @return {@code Page<ExerciseDetailsResponse>} Page com os exercises encontrados.
+   */
+  Page<ExerciseDetailsResponse> fetchExercises(Long workoutId, Pageable pageable);
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/WorkoutService.java
@@ -3,6 +3,7 @@ package br.com.emendes.workout_tracker_api.service;
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
@@ -52,16 +53,26 @@ public interface WorkoutService {
       WeightCreateRequest weightCreateRequest);
 
   /**
-   * Busca paginada de de Workouts, opcional busca por status.
+   * Busca paginada de Workouts, opcional busca por status.
    * <br><br>
    * Se o {@code status} for informado, somente os workouts com tal status serão retornados,
    * caso {@code status} for null, todos os workouts (dentro do limite da paginação) serão retornados.
    *
    * @param status   status dos workouts a ser buscado (pode ser null).
    * @param pageable modo como será feita a paginação dos dados.
-   * @return {@code Page<WorkoutResponse>} Página com os Workout encontrados.
+   * @return {@code Page<WorkoutResponse>} Page com os Workout encontrados.
    */
   Page<WorkoutResponse> fetch(
       @ValidWorkoutStatus(message = "status must be a valid workout status (i.e. ONGOING, FINISHED)") String status,
       @NotNull(message = "pageable must not be null") Pageable pageable);
+
+  /**
+   * Busca paginada de Exercises.
+   *
+   * @param workoutId identificador do Workout relacionado com os exercises.
+   * @param pageable  modo como será feita a paginação dos dados.
+   * @return {@code Page<ExerciseDetailsResponse>} Page com os exercises encontrados.
+   */
+  Page<ExerciseDetailsResponse> fetchExercises(Long workoutId, Pageable pageable);
+
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/ExerciseServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/ExerciseServiceImpl.java
@@ -2,6 +2,7 @@ package br.com.emendes.workout_tracker_api.service.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.exception.ExerciseNotFoundException;
@@ -13,6 +14,8 @@ import br.com.emendes.workout_tracker_api.service.ExerciseService;
 import br.com.emendes.workout_tracker_api.service.WeightService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -54,6 +57,14 @@ public class ExerciseServiceImpl implements ExerciseService {
     }
 
     throw new ExerciseNotFoundException("exercise not found with id: %s".formatted(exerciseId));
+  }
+
+  @Override
+  public Page<ExerciseDetailsResponse> fetchExercises(Long workoutId, Pageable pageable) {
+    log.info("attempt to fetch Exercises with workoutId: {}", workoutId);
+
+    return exerciseRepository.findByWorkoutId(workoutId, pageable)
+        .map(exerciseMapper::toExerciseDetailsResponse);
   }
 
 }

--- a/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
+++ b/src/main/java/br/com/emendes/workout_tracker_api/service/impl/WorkoutServiceImpl.java
@@ -3,6 +3,7 @@ package br.com.emendes.workout_tracker_api.service.impl;
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
@@ -67,6 +68,14 @@ public class WorkoutServiceImpl implements WorkoutService {
 
     log.info("workouts fetched successfully");
     return workoutPage.map(workoutMapper::toWorkoutResponse);
+  }
+
+  @Override
+  public Page<ExerciseDetailsResponse> fetchExercises(Long workoutId, Pageable pageable) {
+    log.info("attempt to fetch exercises related to workout with id: {}", workoutId);
+    verifyIfExistsWorkout(workoutId);
+
+    return exerciseService.fetchExercises(workoutId, pageable);
   }
 
   /**

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/ExerciseMapperImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/mapper/impl/ExerciseMapperImplTest.java
@@ -1,14 +1,19 @@
 package br.com.emendes.workout_tracker_api.unit.mapper.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.mapper.impl.ExerciseMapperImpl;
+import br.com.emendes.workout_tracker_api.mapper.impl.WeightMapperImpl;
+import br.com.emendes.workout_tracker_api.model.UnitOfMeasurement;
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import br.com.emendes.workout_tracker_api.model.entity.Weight;
 import br.com.emendes.workout_tracker_api.model.entity.Workout;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("Unit tests for ExerciseMapperImpl")
 class ExerciseMapperImplTest {
 
-  private final ExerciseMapperImpl exerciseMapper = new ExerciseMapperImpl();
+  private final ExerciseMapperImpl exerciseMapper = new ExerciseMapperImpl(new WeightMapperImpl());
 
   @Test
   @DisplayName("toExercise must return Exercise when map successfully")
@@ -92,6 +97,76 @@ class ExerciseMapperImplTest {
   void toExerciseResponse_MustThrowIllegalArgumentException_WhenExerciseIsNull() {
     Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> exerciseMapper.toExerciseResponse(null))
+        .withMessage("exercise must not be null");
+  }
+
+  @Test
+  @DisplayName("toExerciseDetailsResponse must return ExerciseDetailsResponse with weight when exercise has weight")
+  void toExerciseDetailsResponse_MustReturnExerciseDetailsResponseWithWeight_WhenExerciseHasWeight() {
+    Weight weight = Weight.builder()
+        .id(1_000_000_000L)
+        .value(new BigDecimal("60.0"))
+        .unit(UnitOfMeasurement.KILOGRAMS)
+        .createdAt(LocalDateTime.parse("2025-05-12T12:00:00"))
+        .exercise(Exercise.builder().id(1_000_000L).build())
+        .build();
+    Exercise exercise = Exercise.builder()
+        .id(1_000_000L)
+        .name("Leg press")
+        .description("Exercise that focuses on the quadriceps")
+        .additional("Apply the Rest in Pause technique in the last set")
+        .sets(4)
+        .createdAt(LocalDateTime.parse("2025-05-12T10:00:00"))
+        .weight(weight)
+        .workout(Workout.builder().id(1_000L).build())
+        .build();
+
+    ExerciseDetailsResponse actualExerciseDetailsResponse = exerciseMapper.toExerciseDetailsResponse(exercise);
+
+    assertThat(actualExerciseDetailsResponse).isNotNull();
+    assertThat(actualExerciseDetailsResponse.exercise()).isNotNull()
+        .hasFieldOrPropertyWithValue("id", 1_000_000L)
+        .hasFieldOrPropertyWithValue("name", "Leg press")
+        .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
+        .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
+        .hasFieldOrPropertyWithValue("sets", 4)
+        .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:00:00"))
+        .hasFieldOrPropertyWithValue("updatedAt", null);
+    assertThat(actualExerciseDetailsResponse.weight()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("toExerciseDetailsResponse must return ExerciseDetailsResponse without weight when exercise.weight is null")
+  void toExerciseDetailsResponse_MustReturnExerciseDetailsResponseWithoutWeight_WhenExerciseWeightIsNull() {
+    Exercise exercise = Exercise.builder()
+        .id(1_000_000L)
+        .name("Leg press")
+        .description("Exercise that focuses on the quadriceps")
+        .additional("Apply the Rest in Pause technique in the last set")
+        .sets(4)
+        .createdAt(LocalDateTime.parse("2025-05-12T10:00:00"))
+        .workout(Workout.builder().id(1_000L).build())
+        .build();
+
+    ExerciseDetailsResponse actualExerciseDetailsResponse = exerciseMapper.toExerciseDetailsResponse(exercise);
+
+    assertThat(actualExerciseDetailsResponse).isNotNull();
+    assertThat(actualExerciseDetailsResponse.exercise()).isNotNull()
+        .hasFieldOrPropertyWithValue("id", 1_000_000L)
+        .hasFieldOrPropertyWithValue("name", "Leg press")
+        .hasFieldOrPropertyWithValue("description", "Exercise that focuses on the quadriceps")
+        .hasFieldOrPropertyWithValue("additional", "Apply the Rest in Pause technique in the last set")
+        .hasFieldOrPropertyWithValue("sets", 4)
+        .hasFieldOrPropertyWithValue("createdAt", LocalDateTime.parse("2025-05-12T10:00:00"))
+        .hasFieldOrPropertyWithValue("updatedAt", null);
+    assertThat(actualExerciseDetailsResponse.weight()).isNull();
+  }
+
+  @Test
+  @DisplayName("toExerciseDetailsResponse must throw IllegalArgumentException when exercise is null")
+  void toExerciseDetailsResponse_MustThrowIllegalArgumentException_WhenExerciseIsNull() {
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> exerciseMapper.toExerciseDetailsResponse(null))
         .withMessage("exercise must not be null");
   }
 

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/ExerciseServiceImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/ExerciseServiceImplTest.java
@@ -2,6 +2,7 @@ package br.com.emendes.workout_tracker_api.unit.service.impl;
 
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.exception.ExerciseNotFoundException;
@@ -16,11 +17,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static br.com.emendes.workout_tracker_api.util.ConstantsUtil.DEFAULT_PAGEABLE;
 import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.*;
 import static br.com.emendes.workout_tracker_api.util.faker.WeightFaker.weightResponse;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -115,6 +118,24 @@ class ExerciseServiceImplTest {
       assertThatExceptionOfType(ExerciseNotFoundException.class)
           .isThrownBy(() -> exerciseService.addWeight(9_999_999L, weightCreateRequest))
           .withMessage("exercise not found with id: 9999999");
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FetchExercises Method")
+  class FetchExercises {
+
+    @Test
+    @DisplayName("fetchExercises must return Page<ExerciseDetailsResponse> when fetch successfully")
+    void fetchExercises_MustReturnPageExerciseDetailsResponse_WhenFetchSuccessfully() {
+      when(exerciseRepositoryMock.findByWorkoutId(any(), any())).thenReturn(exercisePage());
+      when(exerciseMapperMock.toExerciseResponse(any())).thenReturn(exerciseResponse());
+
+      Page<ExerciseDetailsResponse> actualExerciseDetailsResponsePage = exerciseService
+          .fetchExercises(1_000L, DEFAULT_PAGEABLE);
+
+      assertThat(actualExerciseDetailsResponsePage).isNotNull().hasSize(1);
     }
 
   }

--- a/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/WorkoutServiceImplTest.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/unit/service/impl/WorkoutServiceImplTest.java
@@ -3,6 +3,7 @@ package br.com.emendes.workout_tracker_api.unit.service.impl;
 import br.com.emendes.workout_tracker_api.dto.request.ExerciseCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WeightCreateRequest;
 import br.com.emendes.workout_tracker_api.dto.request.WorkoutCreateRequest;
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
 import br.com.emendes.workout_tracker_api.dto.response.WorkoutResponse;
@@ -19,12 +20,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
 
+import static br.com.emendes.workout_tracker_api.util.ConstantsUtil.DEFAULT_PAGEABLE;
+import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.exerciseDetailsResponsePage;
 import static br.com.emendes.workout_tracker_api.util.faker.ExerciseFaker.exerciseResponse;
 import static br.com.emendes.workout_tracker_api.util.faker.WeightFaker.weightResponse;
 import static br.com.emendes.workout_tracker_api.util.faker.WorkoutFaker.*;
@@ -169,8 +171,6 @@ class WorkoutServiceImplTest {
   @DisplayName("Fetch Method")
   class FetchMethod {
 
-    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 10);
-
     @Test
     @DisplayName("fetch must return Page<WorkoutResponse> when status is valid")
     void fetch_MustReturnPageWorkoutResponse_WhenStatusIsValid() {
@@ -197,6 +197,37 @@ class WorkoutServiceImplTest {
       verify(workoutMapperMock).toWorkoutResponse(any());
 
       assertThat(actualWorkoutResponsePage).isNotNull().hasSize(1);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FetchExercises Method")
+  class FetchExercisesMethod {
+
+    @Test
+    @DisplayName("fetchExercises must return Page<ExerciseDetailsResponse> when fetch successfully")
+    void fetchExercises_MustReturnPageExerciseDetailsResponse_WhenFetchSuccessfully() {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(true);
+      when(exerciseServiceMock.fetchExercises(any(), any())).thenReturn(exerciseDetailsResponsePage());
+
+      Page<ExerciseDetailsResponse> actualExerciseDetailsResponsePage = workoutService
+          .fetchExercises(1_000L, DEFAULT_PAGEABLE);
+
+      verify(workoutRepositoryMock).existsById(any());
+      verify(exerciseServiceMock).fetchExercises(any(), any());
+
+      assertThat(actualExerciseDetailsResponsePage).isNotNull().hasSize(1);
+    }
+
+    @Test
+    @DisplayName("fetchExercises must throw WorkoutNotFoundException when not found Workout for given id")
+    void fetchExercises_MustThrowWorkoutNotFoundException_WhenNotFoundWorkoutForGivenId() {
+      when(workoutRepositoryMock.existsById(any())).thenReturn(false);
+
+      assertThatExceptionOfType(WorkoutNotFoundException.class)
+          .isThrownBy(() -> workoutService.fetchExercises(9_999L, DEFAULT_PAGEABLE))
+          .withMessage("workout not found with id: 9999");
     }
 
   }

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/ConstantsUtil.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/ConstantsUtil.java
@@ -1,0 +1,16 @@
+package br.com.emendes.workout_tracker_api.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Classe com constantes usados em testes automatizados.
+ */
+public class ConstantsUtil {
+
+  /**
+   * Objeto Pageable padrão com número da página 0, e tamanho da página 10.
+   */
+  public static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 10);
+
+}

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/faker/ExerciseFaker.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/faker/ExerciseFaker.java
@@ -1,11 +1,19 @@
 package br.com.emendes.workout_tracker_api.util.faker;
 
+import br.com.emendes.workout_tracker_api.dto.response.ExerciseDetailsResponse;
 import br.com.emendes.workout_tracker_api.dto.response.ExerciseResponse;
 import br.com.emendes.workout_tracker_api.model.entity.Exercise;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static br.com.emendes.workout_tracker_api.util.faker.WeightFaker.weight;
+import static br.com.emendes.workout_tracker_api.util.faker.WeightFaker.weightResponse;
 import static br.com.emendes.workout_tracker_api.util.faker.WorkoutFaker.workout;
 
 /**
@@ -19,6 +27,7 @@ public class ExerciseFaker {
   public static final String EXERCISE_ADDITIONAL = "Apply the Rest in Pause technique in the last set";
   public static final int EXERCISE_SETS = 4;
   public static final LocalDateTime EXERCISE_CREATED_AT = LocalDateTime.parse("2025-05-12T10:30:00");
+  public static final Pageable EXERCISE_PAGEABLE = PageRequest.of(0, 10);
 
   private ExerciseFaker() {
   }
@@ -63,6 +72,7 @@ public class ExerciseFaker {
         .additional(EXERCISE_ADDITIONAL)
         .sets(EXERCISE_SETS)
         .createdAt(EXERCISE_CREATED_AT)
+        .weight(weight())
         .workout(workout())
         .build();
   }
@@ -72,6 +82,30 @@ public class ExerciseFaker {
    */
   public static Optional<Exercise> exerciseOptional() {
     return Optional.of(exercise());
+  }
+
+  /**
+   * Cria um objeto {@code ExerciseDetailsResponse}.
+   */
+  public static ExerciseDetailsResponse exerciseDetailsResponse() {
+    return ExerciseDetailsResponse.builder()
+        .exercise(exerciseResponse())
+        .weight(weightResponse())
+        .build();
+  }
+
+  /**
+   * Cria um objeto {@code Page<ExerciseDetailsResponse>}.
+   */
+  public static Page<ExerciseDetailsResponse> exerciseDetailsResponsePage() {
+    return new PageImpl<>(List.of(exerciseDetailsResponse()), EXERCISE_PAGEABLE, 1);
+  }
+
+  /**
+   * Cria um objeto {@code Page<Exercise>}.
+   */
+  public static Page<Exercise> exercisePage() {
+    return new PageImpl<>(List.of(exercise()), EXERCISE_PAGEABLE, 1);
   }
 
 }

--- a/src/test/java/br/com/emendes/workout_tracker_api/util/wrapper/ExerciseDetailsResponseWrapper.java
+++ b/src/test/java/br/com/emendes/workout_tracker_api/util/wrapper/ExerciseDetailsResponseWrapper.java
@@ -1,0 +1,25 @@
+package br.com.emendes.workout_tracker_api.util.wrapper;
+
+import br.com.emendes.workout_tracker_api.dto.response.WeightResponse;
+
+import java.time.LocalDateTime;
+
+/**
+ * Record para ser usado em testes automatizados para deserializar JSON
+ * que representa {@code ExerciseDetailsResponse}.
+ * <br><br>
+ * NOTA:<br>
+ * Isso é uma gambiarra, pois {@code ExerciseDetailsResponse} está com o campo {@code exercise} anotado com
+ * {@code JsonUnwrapped}, assim dá erro ao deserializar de volta.
+ */
+public record ExerciseDetailsResponseWrapper(
+    Long id,
+    String name,
+    String description,
+    String additional,
+    int sets,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    WeightResponse weight
+) {
+}


### PR DESCRIPTION
Add endpoint para buscar Exercises de um Workout.

- add endpoint GET /workouts/{workoutId}/exercises
- add WorkoutService.fetchExercises
- add ExerciseService.fetchExercises
- add ExerciseMapper.toExerciseDetailsResponse
- add ExerciseMapperImpl.toExerciseDetailsResponse unit tests
- add WorkoutServiceImpl.fetchExercises unit tests
- add ExerciseServiceImpl.fetchExercises unit tests
- add integration tests do endpoint GET /api/v1/workouts/{workoutId}/exercises